### PR TITLE
Introduce utilities for bootstrapping and maintaining groups in AWS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,4 @@ coverage.txt
 vendor/*/
 
 # Binaries from builds
-controller/*/container/bin/
-plugin/*/container/bin/
+bin/

--- a/bootstrap/cli.go
+++ b/bootstrap/cli.go
@@ -1,0 +1,257 @@
+package bootstrap
+
+import (
+	"encoding/json"
+	"fmt"
+	log "github.com/Sirupsen/logrus"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	machete_aws "github.com/docker/libmachete.aws"
+	"github.com/docker/libmachete/spi/group"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"io/ioutil"
+	"os"
+)
+
+// NewCLI creates a CLI.
+func NewCLI() *CLI {
+	return &CLI{}
+}
+
+// CLI is a CLI for AWS bootstrapping.
+type CLI struct {
+}
+
+func readConfig(swimFile string) (fakeSWIMSchema, error) {
+	swim := fakeSWIMSchema{}
+	swimData, err := ioutil.ReadFile(swimFile)
+	if err != nil {
+		return swim, fmt.Errorf("Failed to read config file: %s", err)
+	}
+
+	err = json.Unmarshal(swimData, &swim)
+	if err != nil {
+		return swim, err
+	}
+
+	err = swim.validate()
+	if err != nil {
+		return swim, err
+	}
+
+	swim.applyDefaults()
+
+	return swim, err
+}
+
+type clusterIDFlags struct {
+	ID clusterID
+}
+
+func (c *clusterIDFlags) flags() *pflag.FlagSet {
+	clusterIDFlags := pflag.NewFlagSet("cluster ID", pflag.ExitOnError)
+	clusterIDFlags.StringVar(&c.ID.region, "region", "", "AWS region")
+	clusterIDFlags.StringVar(&c.ID.name, "cluster", "", "Machete cluster name")
+	return clusterIDFlags
+}
+
+func (c *clusterIDFlags) valid() bool {
+	return c.ID.region != "" && c.ID.name != ""
+}
+
+func abort(format string, args ...interface{}) {
+	log.Fatalf(format, args...)
+	os.Exit(1)
+}
+
+// Command gets the subcommand for the CLI.
+func (a *CLI) Command() *cobra.Command {
+	cmd := cobra.Command{Use: "aws", Short: "manage Swarm clusters in AWS"}
+
+	cluster := clusterIDFlags{}
+
+	var keyName string
+
+	workerSize := 3
+
+	createCmd := cobra.Command{
+		Use:   "create [<swim config>]",
+		Short: "create a swarm cluster",
+		Run: func(cmd *cobra.Command, args []string) {
+			swim := fakeSWIMSchema{}
+			if len(args) == 1 {
+				if keyName != "" || cluster.ID.name != "" || cluster.ID.region != "" {
+					abort("No other cluster-related flags may be set when a SWIM file is used")
+				}
+
+				var err error
+				swim, err = readConfig(args[0])
+				if err != nil {
+					abort("Invalid config file: %s", err)
+				}
+			} else {
+				if keyName == "" || !cluster.valid() {
+					abort("When creating from flags, --key, --cluster, and --region must be provided")
+				}
+
+				instanceConfig := machete_aws.CreateInstanceRequest{
+					RunInstancesInput: ec2.RunInstancesInput{
+						ImageId: aws.String("ami-2ef48339"),
+						KeyName: aws.String(keyName),
+						Placement: &ec2.Placement{
+							// TODO(wfarner): Picking the AZ like this feels hackish.
+							AvailabilityZone: aws.String(cluster.ID.region + "a"),
+						},
+					},
+				}
+
+				swim = fakeSWIMSchema{
+					Driver:      "aws",
+					ClusterName: cluster.ID.name,
+					Groups: []instanceGroup{
+						{
+							Name:   group.ID("Managers"),
+							Type:   managerType,
+							Size:   3,
+							Config: instanceConfig,
+						},
+						{
+							Name:   group.ID("Workers"),
+							Type:   workerType,
+							Size:   workerSize,
+							Config: instanceConfig,
+						},
+					},
+				}
+
+				err := swim.validate()
+				if err != nil {
+					abort(err.Error())
+				}
+
+				swim.applyDefaults()
+			}
+
+			err := bootstrap(swim)
+			if err != nil {
+				abort(err.Error())
+			}
+		},
+	}
+	createCmd.Flags().AddFlagSet(cluster.flags())
+	createCmd.Flags().StringVar(&keyName, "key", "", "The existing SSH key in AWS to use for provisioned instances")
+	createCmd.Flags().IntVar(&workerSize, "worker_size", workerSize, "Size of worker group")
+
+	cmd.AddCommand(&createCmd)
+
+	var swimFile string
+	destroyCmd := cobra.Command{
+		Use:   "destroy",
+		Short: "destroy a swarm cluster",
+		Long: `destroy all resources associated with a SWIM cluster
+
+The cluster may be identified manually or based on the contents of a SWIM file.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			var id clusterID
+			if swimFile == "" {
+				if !cluster.valid() {
+					abort("Must specify --config or both of --region and --cluster")
+				}
+
+				id = cluster.ID
+			} else {
+				swim, err := readConfig(swimFile)
+				if err != nil {
+					abort("Invalid config file: %s", err)
+				}
+				id = swim.cluster()
+			}
+
+			err := destroy(id)
+			if err != nil {
+				abort(err.Error())
+			}
+		},
+	}
+	destroyCmd.Flags().StringVar(&swimFile, "config", "", "A SWIM file")
+
+	destroyCmd.Flags().AddFlagSet(cluster.flags())
+	cmd.AddCommand(&destroyCmd)
+
+	// Commands that are to be executed ON THE SWARM
+	// So in these cases we allow specification of a local api server which can trigger updates.
+	// TODO(chungers) -- the api server will basically become the docker engine subsystem later.
+
+	apiEndpoint := ""
+
+	reconfigureCmd := &cobra.Command{
+		Use: "reconfigure <swim config>",
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) != 1 {
+				cmd.Usage()
+				os.Exit(1)
+			}
+
+			swim, err := readConfig(args[0])
+			if err != nil {
+				abort("Invalid config file: %s", err)
+			}
+
+			// TODO(wfarner): Fetch the existing config and check that the requested change is possible.
+
+			err = swim.push()
+			if err != nil {
+				abort("Failed to push config: %s", err)
+			}
+			log.Infof("Configuration pushed")
+		},
+	}
+	reconfigureCmd.Flags().StringVar(&apiEndpoint, "api", apiEndpoint, "Machete subsystem api endpoint")
+	cmd.AddCommand(reconfigureCmd)
+
+	describeCmd := &cobra.Command{
+		Use: "describe <swim config>",
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) != 1 {
+				cmd.Usage()
+				os.Exit(1)
+			}
+
+			swim, err := readConfig(args[0])
+			if err != nil {
+				abort("Invalid config file: %s", err)
+			}
+
+			groups := []string{}
+			for _, group := range swim.Groups {
+				groups = append(groups, string(group.Name))
+			}
+
+			log.Infof("Groups: %s", groups)
+		},
+	}
+	describeCmd.Flags().StringVar(&apiEndpoint, "api", apiEndpoint, "Machete subsystem api endpoint")
+	cmd.AddCommand(describeCmd)
+
+	statusCmd := &cobra.Command{
+		Use: "status",
+		Run: func(cmd *cobra.Command, args []string) {
+			// TODO(wfarner): Implement.
+
+			log.Infof("Managers: 3 instances")
+			log.Infof("Workers: 5 instances")
+		},
+	}
+	statusCmd.Flags().StringVar(&apiEndpoint, "api", apiEndpoint, "Machete subsystem api endpoint")
+	cmd.AddCommand(statusCmd)
+
+	return &cmd
+}
+
+type logger struct {
+}
+
+func (l logger) Log(args ...interface{}) {
+	log.Println(args)
+}

--- a/bootstrap/create.go
+++ b/bootstrap/create.go
@@ -1,0 +1,662 @@
+package bootstrap
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	log "github.com/Sirupsen/logrus"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/aws/aws-sdk-go/service/iam"
+	machete_aws "github.com/docker/libmachete.aws"
+	"github.com/docker/libmachete/spi/group"
+	"github.com/docker/libmachete/spi/instance"
+	"text/template"
+	"time"
+)
+
+func createEBSVolumes(config client.ConfigProvider, swim fakeSWIMSchema) error {
+	log.Info("Creating EBS volumes")
+	ec2Client := ec2.New(config)
+
+	volumeIDs := []*string{}
+	for _, managerIP := range swim.ManagerIPs {
+		volume, err := ec2Client.CreateVolume(&ec2.CreateVolumeInput{
+			AvailabilityZone: aws.String(swim.availabilityZone()),
+			Size:             aws.Int64(4),
+		})
+		volumeIDs = append(volumeIDs, volume.VolumeId)
+		if err != nil {
+			return err
+		}
+
+		log.Infof("  %s", *volume.VolumeId)
+
+		_, err = ec2Client.CreateTags(&ec2.CreateTagsInput{
+			Resources: []*string{volume.VolumeId},
+			Tags: []*ec2.Tag{
+				swim.cluster().resourceTag(),
+				{
+					Key:   aws.String(machete_aws.VolumeTag),
+					Value: aws.String(managerIP),
+				},
+			},
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func applySubnetAndSecurityGroups(run *ec2.RunInstancesInput, subnetID *string, securityGroupIDs ...*string) {
+	if run.NetworkInterfaces == nil || len(run.NetworkInterfaces) == 0 {
+		run.SubnetId = subnetID
+		run.SecurityGroupIds = securityGroupIDs
+	} else {
+		run.NetworkInterfaces[0].SubnetId = subnetID
+		run.NetworkInterfaces[0].Groups = securityGroupIDs
+	}
+}
+
+func createInternetGateway(ec2Client ec2iface.EC2API, vpcID string, swim fakeSWIMSchema) (*ec2.InternetGateway, error) {
+	internetGateway, err := ec2Client.CreateInternetGateway(&ec2.CreateInternetGatewayInput{})
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = ec2Client.AttachInternetGateway(&ec2.AttachInternetGatewayInput{
+		VpcId:             aws.String(vpcID),
+		InternetGatewayId: internetGateway.InternetGateway.InternetGatewayId,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return internetGateway.InternetGateway, nil
+}
+
+func createRouteTable(
+	ec2Client ec2iface.EC2API,
+	vpcID string,
+	swim fakeSWIMSchema) (*ec2.RouteTable, *ec2.InternetGateway, error) {
+
+	internetGateway, err := createInternetGateway(ec2Client, vpcID, swim)
+	if err != nil {
+		return nil, nil, err
+	}
+	log.Infof("  internet gateway %s", *internetGateway.InternetGatewayId)
+
+	routeTable, err := ec2Client.CreateRouteTable(&ec2.CreateRouteTableInput{VpcId: aws.String(vpcID)})
+	if err != nil {
+		return nil, nil, err
+	}
+	log.Infof("  route table %s", *routeTable.RouteTable.RouteTableId)
+
+	// Route to the internet via the internet gateway.
+	_, err = ec2Client.CreateRoute(&ec2.CreateRouteInput{
+		RouteTableId:         routeTable.RouteTable.RouteTableId,
+		DestinationCidrBlock: aws.String("0.0.0.0/0"),
+		GatewayId:            internetGateway.InternetGatewayId,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return routeTable.RouteTable, internetGateway, nil
+}
+
+func createNetwork(config client.ConfigProvider, swim *fakeSWIMSchema) (string, error) {
+	log.Info("Creating network resources")
+
+	// Apply the private IP address wildcard to the manager.
+	swim.mutateManagers(func(managers *instanceGroup) {
+		if managers.Config.RunInstancesInput.NetworkInterfaces == nil ||
+			len(managers.Config.RunInstancesInput.NetworkInterfaces) == 0 {
+
+			managers.Config.RunInstancesInput.PrivateIpAddress = aws.String("{{.IP}}")
+		} else {
+			managers.Config.RunInstancesInput.NetworkInterfaces[0].PrivateIpAddress = aws.String("{{.IP}}")
+		}
+	})
+
+	ec2Client := ec2.New(config)
+
+	vpc, err := ec2Client.CreateVpc(&ec2.CreateVpcInput{CidrBlock: aws.String("192.168.0.0/16")})
+	if err != nil {
+		return "", err
+	}
+	vpcID := *vpc.Vpc.VpcId
+
+	log.Infof("  VPC %s, waiting for it to become available", vpcID)
+	vpcDescribe := ec2.DescribeVpcsInput{VpcIds: []*string{vpc.Vpc.VpcId}}
+	err = ec2Client.WaitUntilVpcExists(&vpcDescribe)
+	if err != nil {
+		return "", fmt.Errorf("Failed while waiting for VPC to exist - %s", err)
+	}
+
+	err = ec2Client.WaitUntilVpcAvailable(&vpcDescribe)
+	if err != nil {
+		return "", fmt.Errorf("Failed while waiting for VPC to become available - %s", err)
+	}
+
+	_, err = ec2Client.ModifyVpcAttribute(&ec2.ModifyVpcAttributeInput{
+		VpcId:            vpc.Vpc.VpcId,
+		EnableDnsSupport: &ec2.AttributeBooleanValue{Value: aws.Bool(true)},
+	})
+	if err != nil {
+		return "", fmt.Errorf("Failed to modify VPC attribute - %s", err)
+	}
+
+	// The API does not allow enabling DnsSupport and DnsHostnames in the same request, so a second modification
+	// is made for DnsHostnames.
+	_, err = ec2Client.ModifyVpcAttribute(&ec2.ModifyVpcAttributeInput{
+		VpcId:              vpc.Vpc.VpcId,
+		EnableDnsHostnames: &ec2.AttributeBooleanValue{Value: aws.Bool(true)},
+	})
+	if err != nil {
+		return "", fmt.Errorf("Failed to modify VPC attribute - %s", err)
+	}
+
+	workerSubnet, err := ec2Client.CreateSubnet(&ec2.CreateSubnetInput{
+		VpcId:            aws.String(vpcID),
+		CidrBlock:        aws.String("192.168.34.0/24"),
+		AvailabilityZone: aws.String(swim.availabilityZone()),
+	})
+	if err != nil {
+		return "", err
+	}
+	log.Infof("  worker subnet %s", *workerSubnet.Subnet.SubnetId)
+
+	managerSubnet, err := ec2Client.CreateSubnet(&ec2.CreateSubnetInput{
+		VpcId:            aws.String(vpcID),
+		CidrBlock:        aws.String("192.168.33.0/24"),
+		AvailabilityZone: aws.String(swim.availabilityZone()),
+	})
+	if err != nil {
+		return "", err
+	}
+	log.Infof("  manager subnet %s", *managerSubnet.Subnet.SubnetId)
+
+	workerGroupRequest := ec2.CreateSecurityGroupInput{
+		GroupName:   aws.String("WorkerSecurityGroup"),
+		VpcId:       aws.String(vpcID),
+		Description: aws.String("Worker node network rules"),
+	}
+	workerSecurityGroup, err := ec2Client.CreateSecurityGroup(&workerGroupRequest)
+	if err != nil {
+		return "", err
+	}
+	log.Infof("  worker security group %s", *workerSecurityGroup.GroupId)
+
+	managerGroupRequest := ec2.CreateSecurityGroupInput{
+		GroupName:   aws.String("ManagerSecurityGroup"),
+		VpcId:       aws.String(vpcID),
+		Description: aws.String("Manager node network rules"),
+	}
+	managerSecurityGroup, err := ec2Client.CreateSecurityGroup(&managerGroupRequest)
+	if err != nil {
+		return "", err
+	}
+	log.Infof("  manager security group %s", *managerSecurityGroup.GroupId)
+
+	err = configureManagerSecurityGroup(
+		ec2Client,
+		*managerSecurityGroup.GroupId,
+		*managerSubnet.Subnet,
+		*workerSubnet.Subnet)
+	if err != nil {
+		return "", err
+	}
+
+	err = configureWorkerSecurityGroup(ec2Client, *workerSecurityGroup.GroupId, *managerSubnet.Subnet)
+	if err != nil {
+		return "", err
+	}
+
+	routeTable, internetGateway, err := createRouteTable(ec2Client, vpcID, *swim)
+	if err != nil {
+		return "", err
+	}
+
+	_, err = ec2Client.AssociateRouteTable(&ec2.AssociateRouteTableInput{
+		SubnetId:     workerSubnet.Subnet.SubnetId,
+		RouteTableId: routeTable.RouteTableId,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	_, err = ec2Client.AssociateRouteTable(&ec2.AssociateRouteTableInput{
+		SubnetId:     managerSubnet.Subnet.SubnetId,
+		RouteTableId: routeTable.RouteTableId,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	// Tag all resources created.
+	_, err = ec2Client.CreateTags(&ec2.CreateTagsInput{
+		Resources: []*string{
+			vpc.Vpc.VpcId,
+			workerSubnet.Subnet.SubnetId,
+			managerSubnet.Subnet.SubnetId,
+			managerSecurityGroup.GroupId,
+			workerSecurityGroup.GroupId,
+			routeTable.RouteTableId,
+			internetGateway.InternetGatewayId,
+		},
+		Tags: []*ec2.Tag{swim.cluster().resourceTag()},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	swim.mutateGroups(func(group *instanceGroup) {
+		if group.isManager() {
+			applySubnetAndSecurityGroups(
+				&group.Config.RunInstancesInput,
+				managerSubnet.Subnet.SubnetId,
+				managerSecurityGroup.GroupId)
+		} else {
+			applySubnetAndSecurityGroups(
+				&group.Config.RunInstancesInput,
+				workerSubnet.Subnet.SubnetId,
+				workerSecurityGroup.GroupId)
+		}
+	})
+
+	return vpcID, nil
+}
+
+func createAccessRole(config client.ConfigProvider, swim *fakeSWIMSchema) error {
+	log.Info("Creating IAM resources")
+
+	iamClient := iam.New(config)
+
+	// TODO(wfarner): IAM roles are a global concept in AWS, meaning we will probably need to include region
+	// in these entities to avoid collisions.
+	role, err := iamClient.CreateRole(&iam.CreateRoleInput{
+		RoleName: aws.String(swim.cluster().roleName()),
+		AssumeRolePolicyDocument: aws.String(`{
+			"Version" : "2012-10-17",
+			"Statement": [{
+				"Effect": "Allow",
+				"Principal": {
+					"Service": ["ec2.amazonaws.com"]
+				},
+				"Action": ["sts:AssumeRole"]
+			}]
+		}`),
+	})
+	if err != nil {
+		return err
+	}
+
+	log.Infof("  role %s (id %s)", *role.Role.RoleName, *role.Role.RoleId)
+
+	policy, err := iamClient.CreatePolicy(&iam.CreatePolicyInput{
+		PolicyName: aws.String(swim.cluster().managerPolicyName()),
+
+		PolicyDocument: aws.String(`{
+			"Version" : "2012-10-17",
+			"Statement": [{
+				"Effect": "Allow",
+				"Action": "*",
+				"Resource": "*"
+			}]
+		}`),
+	})
+	if err != nil {
+		return err
+	}
+	log.Infof("  policy %s (id %s)", *policy.Policy.PolicyName, *policy.Policy.PolicyId)
+
+	_, err = iamClient.AttachRolePolicy(&iam.AttachRolePolicyInput{
+		RoleName:  role.Role.RoleName,
+		PolicyArn: policy.Policy.Arn,
+	})
+
+	instanceProfile, err := iamClient.CreateInstanceProfile(&iam.CreateInstanceProfileInput{
+		InstanceProfileName: aws.String(swim.cluster().instanceProfileName()),
+	})
+	if err != nil {
+		return err
+	}
+	log.Infof(
+		"  instance profile %s (id %s), waiting for it to exist",
+		*instanceProfile.InstanceProfile.InstanceProfileName,
+		*instanceProfile.InstanceProfile.InstanceProfileId)
+
+	err = iamClient.WaitUntilInstanceProfileExists(&iam.GetInstanceProfileInput{
+		InstanceProfileName: instanceProfile.InstanceProfile.InstanceProfileName,
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = iamClient.AddRoleToInstanceProfile(&iam.AddRoleToInstanceProfileInput{
+		InstanceProfileName: instanceProfile.InstanceProfile.InstanceProfileName,
+		RoleName:            role.Role.RoleName,
+	})
+	if err != nil {
+		return err
+	}
+
+	// TODO(wfarner): The above wait does not seem to be sufficient.  Despite apparently waiting for the instance
+	// profile to exist, we still encounter an error:
+	// "InvalidParameterValue: Value (arn:aws:iam::041673875206:instance-profile/bill-testing-ManagerProfile) for parameter iamInstanceProfile.arn is invalid. Invalid IAM Instance Profile ARN"
+	// The same is true of adding a role to an instance profile:
+	// InvalidParameterValue: IAM Instance Profile "arn:aws:iam::041673875206:instance-profile/bill-testing-ManagerProfile" has no associated IAM Roles
+	// Looks like we may need to poll for the role association as well.
+	time.Sleep(10 * time.Second)
+
+	swim.mutateManagers(func(managers *instanceGroup) {
+		managers.Config.RunInstancesInput.IamInstanceProfile = &ec2.IamInstanceProfileSpecification{
+			Arn: instanceProfile.InstanceProfile.Arn,
+		}
+	})
+
+	return err
+}
+
+func configureManagerSecurityGroup(
+	ec2Client ec2iface.EC2API,
+	groupID string,
+	managerSubnet ec2.Subnet,
+	workerSubnet ec2.Subnet) error {
+
+	// Authorize traffic from worker nodes.
+	_, err := ec2Client.AuthorizeSecurityGroupIngress(&ec2.AuthorizeSecurityGroupIngressInput{
+		GroupId:    &groupID,
+		IpProtocol: aws.String("-1"),
+		FromPort:   aws.Int64(-1),
+		ToPort:     aws.Int64(-1),
+		CidrIp:     workerSubnet.CidrBlock,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Authorize traffic between managers.
+	_, err = ec2Client.AuthorizeSecurityGroupIngress(&ec2.AuthorizeSecurityGroupIngressInput{
+		GroupId:    &groupID,
+		IpProtocol: aws.String("-1"),
+		FromPort:   aws.Int64(-1),
+		ToPort:     aws.Int64(-1),
+		CidrIp:     managerSubnet.CidrBlock,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Authorize SSH to managers.
+	_, err = ec2Client.AuthorizeSecurityGroupIngress(&ec2.AuthorizeSecurityGroupIngressInput{
+		GroupId:    &groupID,
+		IpProtocol: aws.String("tcp"),
+		CidrIp:     aws.String("0.0.0.0/0"),
+		FromPort:   aws.Int64(22),
+		ToPort:     aws.Int64(22),
+	})
+
+	return err
+}
+
+func configureWorkerSecurityGroup(ec2Client ec2iface.EC2API, groupID string, managerSubnet ec2.Subnet) error {
+	// Authorize traffic from manager nodes.
+	_, err := ec2Client.AuthorizeSecurityGroupIngress(&ec2.AuthorizeSecurityGroupIngressInput{
+		GroupId:    aws.String(groupID),
+		IpProtocol: aws.String("-1"),
+		FromPort:   aws.Int64(-1),
+		ToPort:     aws.Int64(-1),
+		CidrIp:     managerSubnet.CidrBlock,
+	})
+
+	return err
+}
+
+// ProvisionManager creates a single manager instance, replacing the IP address wildcard with the provided IP.
+func ProvisionManager(
+	provisioner instance.Plugin,
+	tags map[string]string,
+	provisionRequest json.RawMessage,
+	ip string) error {
+
+	volume := instance.VolumeID(ip)
+
+	id, err := provisioner.Provision(instance.Spec{
+		Properties:       provisionRequest,
+		Tags:             tags,
+		PrivateIPAddress: &ip,
+		Volume:           &volume,
+	})
+	if err != nil {
+		return fmt.Errorf("Failed to provision: %s", err)
+	}
+
+	log.Infof("Provisioned instance %s with IP %s", *id, ip)
+	return nil
+}
+
+// InstanceTags gets the tags used to associate an instance with a group.
+func InstanceTags(resourceTag ec2.Tag, gid group.ID) map[string]string {
+	return map[string]string{
+		*resourceTag.Key: *resourceTag.Value,
+		"group":          string(gid),
+	}
+}
+
+func startInitialManager(config client.ConfigProvider, swim fakeSWIMSchema) error {
+	log.Info("Starting cluster boot leader instance")
+	builder := machete_aws.Builder{Config: config}
+	provisioner, err := builder.BuildInstancePlugin()
+	if err != nil {
+		return err
+	}
+
+	managerGroup := swim.managers()
+
+	rawConfig, err := json.Marshal(managerGroup.Config)
+	if err != nil {
+		return err
+	}
+
+	return ProvisionManager(
+		provisioner,
+		InstanceTags(*swim.cluster().resourceTag(), managerGroup.Name),
+		json.RawMessage(rawConfig),
+		swim.ManagerIPs[0])
+}
+
+const (
+	mountEBSVolume = `
+# This technique may be brittle.  If it proves insufficient, we may want to consider putting the EBS device name
+# in the SWIM config, but this places the burden on the user.
+unmounted=$(blkid -o list | grep '/dev' | grep 'not mounted' | cut -d' ' -f1)
+
+if [ "$unmounted" = "" ]
+then
+  echo 'Did not find an unmounted block device'
+  exit 1
+fi
+
+count=$(echo "$unmounted" | wc -l)
+if [ $count != 1 ]
+then
+  echo "Expected exactly 1 unmounted disk, found $count"
+  exit 1
+fi
+
+mkdir -p /var/lib/docker
+echo "$unmounted /var/lib/docker ext4 defaults,nofail 0 2" > /etc/fstab
+mount -a
+`
+
+	machineBootCommand = `#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+{{.CONFIGURE_HOST}}
+
+start_install() {
+  if command -v docker >/dev/null
+  then
+    echo 'Detected existing Docker installation'
+  else
+    sleep 5
+    curl -sSL https://get.docker.com/ | sh
+  fi
+}
+
+# See https://github.com/docker/docker/issues/23793#issuecomment-237735835 for
+# details on why we background/sleep.
+start_install &
+`
+)
+
+func generateUserData(t *template.Template, swim *fakeSWIMSchema, hostConfigureScript string) string {
+	buffer := bytes.Buffer{}
+	err := t.Execute(&buffer, map[string]string{
+		"SWIM_URL":       swim.cluster().url(),
+		"CONFIGURE_HOST": hostConfigureScript,
+		// Since the join token is not yet known, we re-apply a templated variable, to be filled in by
+		// managers when they are creating instances.
+		"JOIN_TOKEN_ARG": "{{.JOIN_TOKEN_ARG}}",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return string(buffer.Bytes())
+}
+
+func injectUserData(swim *fakeSWIMSchema) error {
+	t, err := template.New("userdata").Parse(machineBootCommand)
+	if err != nil {
+		return fmt.Errorf("Internal UserData template is invalid: %s", err)
+	}
+
+	swim.mutateGroups(func(group *instanceGroup) {
+		var configureHost string
+		if group.isManager() {
+			configureHost = generateUserData(t, swim, mountEBSVolume)
+		} else {
+			configureHost = generateUserData(t, swim, "")
+		}
+
+		group.Config.RunInstancesInput.UserData = aws.String(configureHost)
+	})
+
+	return nil
+}
+
+func bootstrap(swim fakeSWIMSchema) error {
+	sess := swim.cluster().getAWSClient()
+
+	keyNames := []*string{}
+	for _, group := range swim.Groups {
+		keyNames = append(keyNames, group.Config.RunInstancesInput.KeyName)
+	}
+
+	ec2Client := ec2.New(sess)
+	_, err := ec2Client.DescribeKeyPairs(&ec2.DescribeKeyPairsInput{
+		KeyNames: keyNames,
+	})
+	if err != nil {
+		return err
+	}
+
+	err = createAccessRole(sess, &swim)
+	if err != nil {
+		return err
+	}
+
+	vpcID, err := createNetwork(sess, &swim)
+	if err != nil {
+		return err
+	}
+
+	err = injectUserData(&swim)
+	if err != nil {
+		return err
+	}
+
+	err = createEBSVolumes(sess, swim)
+	if err != nil {
+		return err
+	}
+
+	err = swim.push()
+	if err != nil {
+		return err
+	}
+
+	// Create one manager instance.  The manager boot container will handle setting up other containers.
+	err = startInitialManager(sess, swim)
+	if err != nil {
+		return err
+	}
+
+	getInstances := func(req *ec2.DescribeInstancesInput) ([]*ec2.Instance, error) {
+		instances := []*ec2.Instance{}
+
+		instancesResp, err := ec2Client.DescribeInstances(req)
+		if err != nil {
+			return nil, err
+		}
+		for _, reservation := range instancesResp.Reservations {
+			instances = append(instances, reservation.Instances...)
+		}
+		return instances, nil
+	}
+
+	instances, err := getInstances(&ec2.DescribeInstancesInput{Filters: swim.cluster().resourceFilter(vpcID)})
+	if err != nil {
+		return fmt.Errorf("Failed to fetch boot leader: %s", err)
+	}
+	if len(instances) != 1 {
+		log.Warnf("Expected exactly one instance to be starting up, but found %d", len(instances))
+		return nil
+	}
+
+	// Public IP addresses are assigned some time between when an instance is started and when it enters running.
+	// To avoid racing here, we wait until running state to ensure a public IP is assigned.
+	log.Infof("Waiting for boot leader to run")
+	getBootLeader := ec2.DescribeInstancesInput{InstanceIds: []*string{instances[0].InstanceId}}
+	err = ec2Client.WaitUntilInstanceRunning(&getBootLeader)
+	if err != nil {
+		return fmt.Errorf("Failed while waiting for boot leader to start up: %s", err)
+	}
+
+	leaders, err := getInstances(&getBootLeader)
+	if err != nil {
+		return fmt.Errorf("Failed to fetch boot leader: %s", err)
+	}
+	if len(leaders) != 1 {
+		log.Warnf("Expected exactly one boot leader, but found %s", len(instances))
+		return nil
+	}
+
+	leader := leaders[0]
+	if leader.PublicIpAddress == nil {
+		log.Warnf(
+			"Expected instances to have public IPs but %s does not",
+			*leader.InstanceId)
+	} else {
+		log.Infof("")
+		log.Infof("Your Docker cluster is now booting!")
+		log.Infof("")
+		log.Infof("It may take a few more minutes for the cluster to be ready, at which point you can SSH")
+		log.Infof("to %s using the default login user for the AMI, and the private", *leader.PublicIpAddress)
+		log.Infof("SSH key associated with the public key '%s' in AWS.", *leader.KeyName)
+		log.Infof("You can see other nodes tha thave joined the cluster by running 'docker node ls'")
+	}
+
+	return nil
+}

--- a/bootstrap/destroy.go
+++ b/bootstrap/destroy.go
@@ -1,0 +1,266 @@
+package bootstrap
+
+import (
+	"fmt"
+	log "github.com/Sirupsen/logrus"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/iam"
+)
+
+func destroyInstances(config client.ConfigProvider, cluster clusterID, vpcID string) {
+	log.Info("Destroying instances")
+	ec2Client := ec2.New(config)
+
+	instancesResp, err := ec2Client.DescribeInstances(
+		&ec2.DescribeInstancesInput{Filters: cluster.resourceFilter(vpcID)})
+	if err != nil {
+		log.Errorf("  failed to fetch instances: %s", err)
+		return
+	}
+
+	instanceIDs := []*string{}
+	for _, reservation := range instancesResp.Reservations {
+		for _, instance := range reservation.Instances {
+			instanceIDs = append(instanceIDs, instance.InstanceId)
+		}
+	}
+
+	if len(instanceIDs) > 0 {
+		nonPointerIds := []string{}
+		for _, id := range instanceIDs {
+			nonPointerIds = append(nonPointerIds, *id)
+			log.Infof("  %s", *id)
+		}
+
+		_, err = ec2Client.TerminateInstances(&ec2.TerminateInstancesInput{InstanceIds: instanceIDs})
+		if err != nil {
+			log.Errorf("  failed to terminate instances: %s", err)
+			return
+		}
+
+		// TODO(wfarner): Need a more robust routine here since instances can self-replicate.  For example,
+		// the describe/terminate sequence here could race with a manager node trying to reach a target
+		// instance count.
+		err = ec2Client.WaitUntilInstanceTerminated(&ec2.DescribeInstancesInput{InstanceIds: instanceIDs})
+		if err != nil {
+			log.Warnf("  error while waiting for instances to terminate: %s", err)
+		}
+	} else {
+		log.Warnf("  did not find any instances to terminate")
+	}
+}
+
+func destroyEBSVolues(config client.ConfigProvider, cluster clusterID) {
+	log.Info("Destroying EBS volumes")
+	ec2Client := ec2.New(config)
+
+	volumes, err := ec2Client.DescribeVolumes(&ec2.DescribeVolumesInput{
+		Filters: []*ec2.Filter{cluster.clusterFilter()},
+	})
+	if err != nil {
+		log.Warnf("  error while describing volumes: %s", err)
+		return
+	}
+
+	for _, volume := range volumes.Volumes {
+		_, err = ec2Client.DeleteVolume(&ec2.DeleteVolumeInput{VolumeId: volume.VolumeId})
+		if err == nil {
+			log.Infof("  %s", *volume.VolumeId)
+		} else {
+			log.Warnf("  error while deleting volume %s: %s", *volume.VolumeId, err)
+		}
+	}
+}
+
+func destroyAccessRoles(config client.ConfigProvider, cluster clusterID) {
+	log.Info("Destroying IAM resources")
+	iamClient := iam.New(config)
+
+	_, err := iamClient.RemoveRoleFromInstanceProfile(&iam.RemoveRoleFromInstanceProfileInput{
+		InstanceProfileName: aws.String(cluster.instanceProfileName()),
+		RoleName:            aws.String(cluster.roleName()),
+	})
+	if err != nil {
+		log.Warnf("  error while removing role from instance profile: %s", err)
+	}
+
+	log.Infof("  instance profile %s", cluster.instanceProfileName())
+	_, err = iamClient.DeleteInstanceProfile(&iam.DeleteInstanceProfileInput{
+		InstanceProfileName: aws.String(cluster.instanceProfileName()),
+	})
+	if err != nil {
+		log.Warnf("  error while deleting instance profile: %s", err)
+	}
+
+	// There must be a better way...but i couldn't find another way to look up the policy ARN.
+	policies, err := iamClient.ListPolicies(&iam.ListPoliciesInput{
+		Scope: aws.String("Local"),
+	})
+	for _, policy := range policies.Policies {
+		if *policy.PolicyName == cluster.managerPolicyName() {
+			_, err = iamClient.DetachRolePolicy(&iam.DetachRolePolicyInput{
+				RoleName:  aws.String(cluster.roleName()),
+				PolicyArn: policy.Arn,
+			})
+			if err != nil {
+				log.Warnf("  error while detaching role policy: %s", err)
+			}
+
+			log.Infof("  policy %s", *policy.Arn)
+			_, err = iamClient.DeletePolicy(&iam.DeletePolicyInput{
+				PolicyArn: policy.Arn,
+			})
+			if err != nil {
+				log.Warnf("  error while deleting policy: %s", err)
+			}
+		}
+	}
+
+	if err != nil {
+		log.Warnf("  error while deleting role policy: %s", err)
+	}
+
+	log.Infof("  role %s", cluster.roleName())
+	_, err = iamClient.DeleteRole(&iam.DeleteRoleInput{RoleName: aws.String(cluster.roleName())})
+	if err != nil {
+		log.Warnf("  error while deleting IAM role: %s", err)
+	}
+}
+
+func destroyNetwork(config client.ConfigProvider, cluster clusterID, vpcID string) {
+	log.Info("Destroying network resources")
+	ec2Client := ec2.New(config)
+
+	securityGroups, err := ec2Client.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+		Filters: cluster.resourceFilter(vpcID),
+	})
+	if err == nil {
+		for _, securityGroup := range securityGroups.SecurityGroups {
+			log.Infof("  security group %s", *securityGroup.GroupId)
+			_, err = ec2Client.DeleteSecurityGroup(&ec2.DeleteSecurityGroupInput{
+				GroupId: securityGroup.GroupId,
+			})
+			if err != nil {
+				log.Warnf("  error while deleting security group: %s", err)
+			}
+		}
+	} else {
+		log.Warnf("  error while describing security groups: %s", err)
+	}
+
+	subnets, err := ec2Client.DescribeSubnets(&ec2.DescribeSubnetsInput{Filters: []*ec2.Filter{
+		{
+			Name:   aws.String("vpc-id"),
+			Values: []*string{aws.String(vpcID)},
+		},
+		cluster.clusterFilter(),
+	}})
+	if err == nil {
+		for _, subnet := range subnets.Subnets {
+			log.Infof("  subnet %s", *subnet.SubnetId)
+			_, err = ec2Client.DeleteSubnet(&ec2.DeleteSubnetInput{SubnetId: subnet.SubnetId})
+			if err != nil {
+				log.Warnf("  error while deleting subnet: %s", err)
+			}
+		}
+	} else {
+		log.Warnf("  error while looking up subnets: %s", err)
+	}
+
+	internetGateways, err := ec2Client.DescribeInternetGateways(&ec2.DescribeInternetGatewaysInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("attachment.vpc-id"),
+				Values: []*string{aws.String(vpcID)},
+			},
+			cluster.clusterFilter(),
+		},
+	})
+	if err == nil {
+		for _, internetGateway := range internetGateways.InternetGateways {
+			log.Infof(
+				"  detaching internet gateway %s from VPC %s",
+				*internetGateway.InternetGatewayId,
+				vpcID)
+			_, err := ec2Client.DetachInternetGateway(&ec2.DetachInternetGatewayInput{
+				InternetGatewayId: internetGateway.InternetGatewayId,
+				VpcId:             aws.String(vpcID),
+			})
+			if err != nil {
+				log.Warnf("  error detaching internet gateways: %s", err)
+			}
+
+			log.Infof("  internet gateway %s", *internetGateway.InternetGatewayId)
+			_, err = ec2Client.DeleteInternetGateway(&ec2.DeleteInternetGatewayInput{
+				InternetGatewayId: internetGateway.InternetGatewayId,
+			})
+			if err != nil {
+				log.Warnf("  error deleting internet gateways: %s", err)
+			}
+		}
+	} else {
+		log.Warnf("  error looking up internet gateways: %s", err)
+	}
+
+	routeTables, err := ec2Client.DescribeRouteTables(
+		&ec2.DescribeRouteTablesInput{Filters: cluster.resourceFilter(vpcID)})
+	if err == nil {
+		for _, routeTable := range routeTables.RouteTables {
+			log.Infof("  route table %s", *routeTable.RouteTableId)
+			_, err = ec2Client.DeleteRouteTable(&ec2.DeleteRouteTableInput{
+				RouteTableId: routeTable.RouteTableId,
+			})
+			if err != nil {
+				log.Warnf("  error while deleting route table: %s", err)
+			}
+		}
+	} else {
+		log.Warnf("  error while describing route tables: %s", err)
+	}
+
+	log.Infof("  VPC %s", vpcID)
+	_, err = ec2Client.DeleteVpc(&ec2.DeleteVpcInput{VpcId: aws.String(vpcID)})
+	if err != nil {
+		log.Warnf("  error while deleting VPC: %s", err)
+	}
+}
+
+func destroy(cluster clusterID) error {
+	sess := cluster.getAWSClient()
+	ec2Client := ec2.New(sess)
+
+	vpcs, err := ec2Client.DescribeVpcs(&ec2.DescribeVpcsInput{Filters: []*ec2.Filter{cluster.clusterFilter()}})
+	if err != nil {
+		return fmt.Errorf("Failed to look up VPC: %s", err)
+	}
+
+	// TODO(wfarner): We omit the VPC ID from resource tags and allow more failure-resistant cleanup as long as we
+	// disallow clusters of the same name to exist within a region.
+	var vpcID string
+	switch len(vpcs.Vpcs) {
+	case 0:
+		log.Warnf("No VPCs found for cluster %s, unable to remove networks or instances", cluster.name)
+	case 1:
+		vpcID = *vpcs.Vpcs[0].VpcId
+	default:
+		log.Warnf(
+			"Found multiple VPCs for cluster %s, unable to remove networks or instances",
+			cluster.name)
+	}
+
+	if vpcID != "" {
+		destroyInstances(sess, cluster, vpcID)
+	}
+
+	destroyEBSVolues(sess, cluster)
+
+	destroyAccessRoles(sess, cluster)
+
+	if vpcID != "" {
+		destroyNetwork(sess, cluster, vpcID)
+	}
+
+	return nil
+}

--- a/bootstrap/formatter.go
+++ b/bootstrap/formatter.go
@@ -1,0 +1,168 @@
+package bootstrap
+
+import (
+	"bytes"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	log "github.com/Sirupsen/logrus"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"strings"
+	"text/template"
+	"time"
+)
+
+func formatVolumes(config client.ConfigProvider, swim fakeSWIMSchema, volumeIDs []*string) error {
+	log.Info("Formatting Swarm data EBS volumes")
+
+	// TODO(wfarner): Could we instead format on the bootstrap volume, as part of other bootstrap operations
+	// (like `docker swarm init`)?
+
+	// On the host OS we are using to format, mounted block devices appear as '/dev/xvdX' even though we ask EC2
+	// to mount as '/dev/sdX'.  This behavior is explicitly mentioned in
+	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html#device-name-limits
+	volumeLetters := []string{"f", "g", "h", "i", "j", "k", "l"}
+	volumeToName := map[string]string{}
+	hostDeviceNames := []string{}
+	for index, volumeID := range volumeIDs {
+		letter := volumeLetters[index]
+		volumeToName[*volumeID] = fmt.Sprintf("/dev/sd%s", letter)
+		hostDeviceNames = append(hostDeviceNames, fmt.Sprintf("/dev/xvd%s", letter))
+	}
+
+	userDataTemplate := template.Must(template.New("userdata").Parse(userData))
+	buffer := bytes.Buffer{}
+	err := userDataTemplate.Execute(&buffer, map[string]string{"Devices": strings.Join(hostDeviceNames, " ")})
+	if err != nil {
+		return fmt.Errorf("Failed to generate UserData: %s", err)
+	}
+
+	// TODO(wfarner): Need to pick the appropriate image based on the region.
+	ec2Client := ec2.New(config)
+	instance, err := ec2Client.RunInstances(&ec2.RunInstancesInput{
+		InstanceType: aws.String("t2.micro"),
+		KeyName:      swim.managers().Config.RunInstancesInput.KeyName,
+		ImageId:      aws.String("ami-2ef48339"),
+		Placement: &ec2.Placement{
+			AvailabilityZone: aws.String(swim.availabilityZone()),
+		},
+		UserData: aws.String(base64.StdEncoding.EncodeToString([]byte(buffer.String()))),
+		MinCount: aws.Int64(1),
+		MaxCount: aws.Int64(1),
+	})
+	if err != nil {
+		return fmt.Errorf("Failed to start formatter instance: %s", err)
+	}
+	formatterInstance := instance.Instances[0].InstanceId
+
+	_, err = ec2Client.CreateTags(&ec2.CreateTagsInput{
+		Resources: []*string{formatterInstance},
+		Tags: []*ec2.Tag{
+			swim.cluster().resourceTag(),
+			{
+				Key:   aws.String("Name"),
+				Value: aws.String(fmt.Sprintf("%s formatter", swim.cluster().name)),
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("Error while tagging formatter instance: %s", err)
+	}
+
+	log.Infof("  created EBS formatter instance %s, waiting for it to run", *formatterInstance)
+	getFormatter := ec2.DescribeInstancesInput{InstanceIds: []*string{formatterInstance}}
+	err = ec2Client.WaitUntilInstanceRunning(&getFormatter)
+	if err != nil {
+		return fmt.Errorf("Error while waiting for formatter instance to start: %s", err)
+	}
+
+	for volumeID, deviceName := range volumeToName {
+		_, err = ec2Client.AttachVolume(&ec2.AttachVolumeInput{
+			InstanceId: formatterInstance,
+			VolumeId:   aws.String(volumeID),
+			Device:     aws.String(deviceName),
+		})
+		if err != nil {
+			return fmt.Errorf("Error while attaching volume %s for formatting: %s", volumeID, err)
+		}
+	}
+
+	// TODO(wfarner): Include a timeout for this.
+	log.Info("  attached volumes to formatter, waiting for it to boot and format")
+	formattingFailed := true
+	for {
+		time.Sleep(10 * time.Second)
+
+		// This is an especially primitive way to collect exit status, but the upside is that it requires
+		// no additional machinery or network access.
+		console, err := ec2Client.GetConsoleOutput(&ec2.GetConsoleOutputInput{InstanceId: formatterInstance})
+		if err != nil {
+			return fmt.Errorf("Error while fetching formatter instance console: %s", err)
+		}
+
+		if console.Output != nil {
+			consoleData, err := base64.StdEncoding.DecodeString(*console.Output)
+			if err != nil {
+				return fmt.Errorf("Error while decoding formatter console text: %s", err)
+			}
+
+			consoleText := string(consoleData)
+			if strings.Contains(consoleText, "MACHETE FORMATTING FINISHED: success") {
+				log.Info("  formatting complete")
+				formattingFailed = false
+				break
+			} else if strings.Contains(consoleText, "MACHETE FORMATTING FINISHED: unexpected exit") {
+				log.Fatal("  failed to format EBS volumes.  See console output below.")
+				log.Fatal(consoleText)
+				break
+			}
+		}
+	}
+
+	_, err = ec2Client.TerminateInstances(&ec2.TerminateInstancesInput{InstanceIds: []*string{formatterInstance}})
+	if err != nil {
+		return fmt.Errorf("Error while terminating formatter instance: %s", err)
+	}
+
+	log.Info("  waiting for formatter instance to terminate")
+	err = ec2Client.WaitUntilInstanceTerminated(&getFormatter)
+	if err != nil {
+		return fmt.Errorf("Error while waiting for formatter instance to terminate: %s", err)
+	}
+
+	if formattingFailed {
+		return errors.New("Failed to format EBS voluems")
+	}
+	return nil
+}
+
+const userData = `#!/bin/sh
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+ls -l /dev
+
+completed=false
+onexit () {
+  if [ "$completed" = true ]
+  then
+    echo 'MACHETE FORMATTING FINISHED: success'
+  else
+    echo 'MACHETE FORMATTING FINISHED: unexpected exit'
+  fi
+}
+
+trap onexit EXIT
+
+for device in {{.Devices}}
+do
+  mkfs -t ext4 $device
+done
+
+completed=true
+`

--- a/bootstrap/plugin_client.go
+++ b/bootstrap/plugin_client.go
@@ -1,0 +1,69 @@
+package bootstrap
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/libmachete/controller/util"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"path/filepath"
+	"strings"
+)
+
+// Client is the client that can access the driver either via tcp or unix
+type Client struct {
+	UnixSocket string
+	c          *http.Client
+	Host       string
+}
+
+// NewClient creates a client to the controller
+func NewClient(socket string) *Client {
+	client := &http.Client{}
+
+	host := filepath.Base(socket) // for host name in case it's tcp
+	index := strings.Index(host, ":")
+	if index == 0 {
+		// e.g. :9090 ==> change to localhost:9090, otherwise take the host:port as is.
+		host = "localhost" + host
+	}
+
+	if util.ProtocolFromListenString(socket) == "unix" {
+		client.Transport = &http.Transport{
+			Dial: func(proto, addr string) (conn net.Conn, err error) {
+				return net.Dial("unix", socket)
+			},
+		}
+		host = "local" // dummy host for unix socket
+	}
+	return &Client{
+		UnixSocket: socket,
+		c:          client,
+		Host:       host,
+	}
+}
+
+// Call makes a POST call of the form of /v1/{op}.  For example  /v1/scaler.Start
+func (d *Client) Call(op string, req interface{}) error {
+	buff, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("http://%s/v1/%s", d.Host, op)
+	resp, err := d.c.Post(url, "application/json", bytes.NewBuffer(buff))
+	if err != nil {
+		return err
+	}
+	buff, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	log.Infoln("Resp", string(buff))
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("error from controller:%d, msg=%s", resp.StatusCode, string(buff))
+	}
+	return nil
+}

--- a/bootstrap/scale.go
+++ b/bootstrap/scale.go
@@ -1,0 +1,61 @@
+package bootstrap
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	log "github.com/Sirupsen/logrus"
+	"io/ioutil"
+	"net/http"
+	"os"
+)
+
+func scale(cluster clusterID, groupName string, count int) (*fakeSWIMSchema, error) {
+	log.Infoln("Fetching from", cluster.url())
+	resp, err := http.Get(cluster.url())
+	if err != nil {
+		abort("Failed to fetch current configuration: %s", err)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to read response when fetching configuration: %s", err)
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("Failed to fetch current configuration: %s", string(body))
+	}
+
+	swim := fakeSWIMSchema{}
+	err = json.Unmarshal(body, &swim)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to parse existing configuration: %s", err)
+	}
+
+	matched := false
+	swim.mutateGroups(func(group *instanceGroup) {
+		if string(group.Name) == groupName {
+			matched = true
+			if group.isManager() {
+				err = errors.New("A manager group may not be scaled")
+			}
+
+			group.Size = count
+		}
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if !matched {
+		log.Fatalf("Config does not contain a group named %s", groupName)
+		os.Exit(1)
+	}
+
+	err = swim.push()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to push config: %s", err)
+	}
+
+	log.Infof("Target count for group %s is now %d", groupName, count)
+	return &swim, nil
+}

--- a/bootstrap/schema.go
+++ b/bootstrap/schema.go
@@ -1,0 +1,318 @@
+package bootstrap
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	log "github.com/Sirupsen/logrus"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/s3"
+	machete_aws "github.com/docker/libmachete.aws"
+	"github.com/docker/libmachete/spi/group"
+	"strings"
+)
+
+const (
+	workerType  = "worker"
+	managerType = "manager"
+	s3File      = "config.swim"
+)
+
+type clusterID struct {
+	region string
+	name   string
+}
+
+func (c clusterID) getAWSClient() client.ConfigProvider {
+	providers := []credentials.Provider{
+		&ec2rolecreds.EC2RoleProvider{Client: ec2metadata.New(session.New())},
+		&credentials.EnvProvider{},
+		&credentials.SharedCredentialsProvider{},
+	}
+
+	return session.New(aws.NewConfig().
+		WithRegion(c.region).
+		WithCredentialsChainVerboseErrors(true).
+		WithCredentials(credentials.NewChainCredentials(providers)).
+		WithLogger(&logger{}))
+}
+
+func (c clusterID) url() string {
+	return fmt.Sprintf(
+		"https://machete-cluster.s3-%s.amazonaws.com/%s/%s",
+		c.region,
+		c.name,
+		s3File)
+}
+
+func (c clusterID) resourceFilter(vpcID string) []*ec2.Filter {
+	return []*ec2.Filter{
+		{
+			Name:   aws.String("vpc-id"),
+			Values: []*string{aws.String(vpcID)},
+		},
+		c.clusterFilter(),
+	}
+}
+
+func (c clusterID) clusterFilter() *ec2.Filter {
+	return &ec2.Filter{
+		Name:   aws.String("tag:machete-cluster"),
+		Values: []*string{aws.String(c.name)},
+	}
+}
+
+func (c clusterID) roleName() string {
+	return fmt.Sprintf("%s-ManagerRole", c.name)
+}
+
+func (c clusterID) managerPolicyName() string {
+	return fmt.Sprintf("%s-ManagerPolicy", c.name)
+}
+
+func (c clusterID) instanceProfileName() string {
+	return fmt.Sprintf("%s-ManagerProfile", c.name)
+}
+
+func (c clusterID) resourceTag() *ec2.Tag {
+	return &ec2.Tag{
+		Key:   aws.String("machete-cluster"),
+		Value: aws.String(c.name),
+	}
+}
+
+type instanceGroup struct {
+	Name   group.ID
+	Type   string
+	Size   int
+	Config machete_aws.CreateInstanceRequest
+}
+
+func (i instanceGroup) isManager() bool {
+	return i.Type == managerType
+}
+
+type fakeSWIMSchema struct {
+	Driver      string
+	ClusterName string
+	ManagerIPs  []string
+	Groups      []instanceGroup
+}
+
+func (s *fakeSWIMSchema) cluster() clusterID {
+	az := s.availabilityZone()
+	return clusterID{region: az[:len(az)-1], name: s.ClusterName}
+}
+
+func (s *fakeSWIMSchema) push() error {
+	swimData, err := json.Marshal(*s)
+	if err != nil {
+		return err
+	}
+
+	s3Client := s3.New(s.cluster().getAWSClient())
+
+	bucket := aws.String("machete-cluster")
+	head := &s3.HeadBucketInput{Bucket: bucket}
+
+	_, err = s3Client.HeadBucket(head)
+	if err != nil {
+		// The bucket does not appear to exist.  Try to create it.
+		bucketCreateResult, err := s3Client.CreateBucket(&s3.CreateBucketInput{
+			Bucket: bucket,
+		})
+		if err != nil {
+			return err
+		}
+
+		log.Infof("Created S3 bucket: %s", *bucketCreateResult.Location)
+
+		err = s3Client.WaitUntilBucketExists(head)
+		if err != nil {
+			return err
+		}
+	}
+
+	key := aws.String(fmt.Sprintf("%s/%s", s.ClusterName, s3File))
+
+	// Note - this will overwrite an existing object.
+	putRequest, _ := s3Client.PutObjectRequest(&s3.PutObjectInput{
+		Bucket: bucket,
+		Key:    key,
+		// TODO(wfarner): Explore tightening permissions, as these URLs are reasonably guessable and could
+		// potentially contain sensitive information in the future.
+		ACL:         aws.String("public-read"),
+		Body:        bytes.NewReader(swimData),
+		ContentType: aws.String("application/json"),
+	})
+
+	err = putRequest.Send()
+	if err != nil {
+		return err
+	}
+
+	if putRequest.HTTPRequest.URL.String() != s.cluster().url() {
+		log.Warnf(
+			"Expected config URL %s, but received %s",
+			s.cluster().url(),
+			putRequest.HTTPRequest.URL.String())
+	}
+
+	return nil
+}
+
+func (s *fakeSWIMSchema) managers() instanceGroup {
+	for _, group := range s.Groups {
+		if group.isManager() {
+			return group
+		}
+	}
+	panic("No manager group found")
+}
+
+func (s *fakeSWIMSchema) mutateManagers(op func(*instanceGroup)) {
+	s.mutateGroups(func(group *instanceGroup) {
+		if group.isManager() {
+			op(group)
+		}
+	})
+}
+
+func (s *fakeSWIMSchema) mutateGroups(op func(*instanceGroup)) {
+	for i, group := range s.Groups {
+		op(&group)
+		s.Groups[i] = group
+	}
+}
+
+func applyInstanceDefaults(r *ec2.RunInstancesInput) {
+	if r.InstanceType == nil {
+		r.InstanceType = aws.String("t2.micro")
+	}
+
+	if r.NetworkInterfaces == nil || len(r.NetworkInterfaces) == 0 {
+		r.NetworkInterfaces = []*ec2.InstanceNetworkInterfaceSpecification{
+			{
+				AssociatePublicIpAddress: aws.Bool(true),
+				DeleteOnTermination:      aws.Bool(true),
+				DeviceIndex:              aws.Int64(0),
+			},
+		}
+	}
+}
+
+func (s *fakeSWIMSchema) applyDefaults() {
+	s.mutateGroups(func(group *instanceGroup) {
+		if group.Type == managerType {
+			bootLeaderLastOctet := 4
+			s.ManagerIPs = []string{}
+			for i := 0; i < group.Size; i++ {
+				s.ManagerIPs = append(s.ManagerIPs, fmt.Sprintf("192.168.33.%d", bootLeaderLastOctet+i))
+			}
+		}
+
+		applyInstanceDefaults(&group.Config.RunInstancesInput)
+	})
+}
+
+func (s *fakeSWIMSchema) validate() error {
+	errs := []string{}
+
+	addError := func(format string, a ...interface{}) {
+		errs = append(errs, fmt.Sprintf(format, a...))
+	}
+
+	managerGroups := 0
+	workerGroups := 0
+	for _, group := range s.Groups {
+		switch group.Type {
+		case managerType:
+			managerGroups++
+		case workerType:
+			workerGroups++
+		default:
+			errs = append(
+				errs,
+				fmt.Sprintf(
+					"Invalid instance type '%s', must be %s or %s",
+					group.Type,
+					workerType,
+					managerType))
+		}
+	}
+
+	if managerGroups != 1 {
+		addError("Must specify exactly one group of type %s", managerType)
+	}
+
+	/*
+		if workerGroups == 0 {
+			addError("Must specify exactly one group of type %s", workerType)
+		}
+	*/
+
+	if s.ClusterName == "" {
+		addError("Must specify ClusterName")
+	}
+
+	for _, group := range s.Groups {
+		if group.isManager() {
+			if group.Size != 1 && group.Size != 3 && group.Size != 5 {
+				addError("Group %s Size must be 1, 3, or 5", group.Name)
+			}
+		} else {
+			if group.Size < 1 {
+				addError("Group %s Size must be at least 1", group.Name)
+			}
+		}
+	}
+
+	validateGroup := func(gid group.ID, group instanceGroup) {
+		errorPrefix := fmt.Sprintf("In group %s: ", gid)
+
+		if group.Config.RunInstancesInput.Placement == nil {
+			addError(errorPrefix + "run_instance_input.Placement must be set")
+		} else if group.Config.RunInstancesInput.Placement.AvailabilityZone == nil ||
+			*group.Config.RunInstancesInput.Placement.AvailabilityZone == "" {
+
+			addError(errorPrefix + "run_instance_nput.Placement.AvailabilityZone must be set")
+		}
+	}
+
+	// MVP restriction - all groups must be in the same Availability Zone.
+	firstAz := ""
+	for _, group := range s.Groups {
+		validateGroup(group.Name, group)
+
+		if group.Config.RunInstancesInput.Placement != nil {
+			az := *group.Config.RunInstancesInput.Placement.AvailabilityZone
+			if firstAz == "" {
+				firstAz = az
+			} else if az != firstAz {
+				addError(
+					"All groups must specify the same run_instance_nput.Placement.AvailabilityZone")
+				break
+			}
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, "\n"))
+	}
+
+	return nil
+}
+
+func (s *fakeSWIMSchema) availabilityZone() string {
+	for _, group := range s.Groups {
+		return *group.Config.RunInstancesInput.Placement.AvailabilityZone
+	}
+	panic("No groups")
+}

--- a/bootstrap/test.json
+++ b/bootstrap/test.json
@@ -1,0 +1,32 @@
+{
+  "Driver": "aws",
+  "ClusterName": "bill-testing",
+  "Groups": {
+    "Managers": {
+      "Type": "manager",
+      "Size": 1,
+      "Config": {
+        "run_instances_input": {
+          "ImageId": "ami-f701cb97",
+          "KeyName": "bill-laptop",
+          "Placement": {
+            "AvailabilityZone": "us-west-2a"
+          }
+        }
+      }
+    },
+    "Workers": {
+      "Type": "worker",
+      "Size": 3,
+      "Config": {
+        "run_instances_input": {
+          "ImageId": "ami-f701cb97",
+          "KeyName": "bill-laptop",
+          "Placement": {
+            "AvailabilityZone": "us-west-2a"
+          }
+        }
+      }
+    }
+  }
+}

--- a/builder.go
+++ b/builder.go
@@ -40,7 +40,7 @@ func (b *Builder) Flags() *pflag.FlagSet {
 	return flags
 }
 
-// BuildInstanceProvisioner creates an instance Provisioner configured with the Flags.
+// BuildInstancePlugin creates an instance Provisioner configured with the Flags.
 func (b *Builder) BuildInstancePlugin() (instance.Plugin, error) {
 	if b.Config == nil {
 		providers := []credentials.Provider{
@@ -74,7 +74,7 @@ func (b *Builder) BuildInstancePlugin() (instance.Plugin, error) {
 		b.Config = session.New(aws.NewConfig().
 			WithRegion(b.options.region).
 			WithCredentials(credentials.NewChainCredentials(providers)).
-			WithLogger(getLogger()).
+			WithLogger(GetLogger()).
 			//WithLogLevel(aws.LogDebugWithRequestErrors).
 			WithMaxRetries(b.options.retries))
 	}
@@ -90,7 +90,8 @@ func (l logger) Log(args ...interface{}) {
 	l.logger.Println(args...)
 }
 
-func getLogger() aws.Logger {
+// GetLogger gets a logger that can be used with the AWS SDK.
+func GetLogger() aws.Logger {
 	return &logger{
 		logger: log.New(os.Stderr, "", log.LstdFlags),
 	}

--- a/cmd/machetectl/README.md
+++ b/cmd/machetectl/README.md
@@ -1,0 +1,1 @@
+POC code only

--- a/cmd/machetectl/container/Dockerfile
+++ b/cmd/machetectl/container/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:3.4
+
+MAINTAINER David Chung <david.chung@docker.com>
+
+RUN apk add --update ca-certificates && rm -Rf /tmp/* /var/lib/cache/apk/*
+
+# needed in order for go binary to work.
+RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
+
+ADD bin/matchetectl /usr/local/bin/
+
+ENTRYPOINT [ "matchetectl" ]

--- a/cmd/machetectl/container/Makefile
+++ b/cmd/machetectl/container/Makefile
@@ -1,0 +1,43 @@
+# Makefile for building the watcher controller
+#
+# We use a container to compile the binary, and in
+# the container we use govendor to fetch all the versioned
+# packages and dependencies.
+# If you need to change the version of a package, update
+# the vendor/vendor.json and the build container will
+# automatically pull in the versioned dependencies without
+# changing your local workspace.
+
+# Build version metadata
+VERSION?=0.0-snapshot
+REVISION=$(shell git rev-list -1 HEAD)
+
+DOCKER_REPO_OWNER?=libmachete
+DOCKER_REPO?=${DOCKER_REPO_OWNER}/machetectl
+DOCKER_TAG?=dev
+DOCKER_IMAGE=${DOCKER_REPO}:${DOCKER_TAG}
+
+.PHONY: clean all container
+.DEFAULT: all
+all: container
+
+clean:
+	@echo "+ $@"
+	rm -rf bin
+	@# Remove local images
+	docker rmi -f ${DOCKER_IMAGE} >/dev/null 2>&1 || true
+	docker rmi -f ${DOCKER_REPO}:latest >/dev/null 2>&1 || true
+
+container: clean
+	@echo "+ $@"
+	mkdir -p bin
+	cd ../../.. && LDFLAGS="-X main.Version=$(VERSION) -X main.Revision=$(REVISION)" \
+	  ./hack/build-in-docker 'cmd/machetectl/*.go' cmd/machetectl/container/bin/matchetectl
+	docker build -t $(DOCKER_IMAGE) -t $(DOCKER_REPO):latest -t $(DOCKER_REPO):$(VERSION) .
+
+ifeq (${DOCKER_PUSH},true)
+	docker push ${DOCKER_IMAGE}
+ifeq (${DOCKER_TAG_LATEST},true)
+	docker push ${DOCKER_REPO}:latest
+endif
+endif

--- a/cmd/machetectl/main.go
+++ b/cmd/machetectl/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/libmachete.aws/bootstrap"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+var (
+	// Version is the build release identifier.
+	Version = "Unspecified"
+
+	// Revision is the build source control revision.
+	Revision = "Unspecified"
+)
+
+func attachDriver(rootCmd *cobra.Command, cli *bootstrap.CLI, requiredName string) {
+	cmd := cli.Command()
+	if cmd.Name() != requiredName {
+		panic(fmt.Sprintf("Internal error - driver must use name '%s'", requiredName))
+	}
+
+	rootCmd.AddCommand(cmd)
+}
+
+func main() {
+	rootCmd := &cobra.Command{Use: "machetecli"}
+
+	rootCmd.AddCommand(&cobra.Command{
+		Use:   "version",
+		Short: "print build version information",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("%s (revision %s)\n", Version, Revision)
+		},
+	})
+
+	attachDriver(rootCmd, bootstrap.NewCLI(), "aws")
+
+	err := rootCmd.Execute()
+	if err != nil {
+		log.Print(err)
+		os.Exit(-1)
+	}
+}

--- a/instance_test.go
+++ b/instance_test.go
@@ -41,7 +41,7 @@ func TestInstanceLifecycle(t *testing.T) {
 	clientMock.EXPECT().CreateTags(&tagRequest).Return(&ec2.CreateTagsOutput{}, nil)
 
 	// TODO(wfarner): Test user-data and private IP plumbing.
-	id, err := provisioner.Provision(inputJSON, tags, "", nil, nil)
+	id, err := provisioner.Provision(instance.Spec{Properties: inputJSON, Tags: tags})
 
 	require.NoError(t, err)
 	require.Equal(t, instanceID, string(*id))
@@ -65,7 +65,7 @@ func TestCreateInstanceError(t *testing.T) {
 	clientMock.EXPECT().RunInstances(gomock.Any()).Return(&ec2.Reservation{}, runError)
 
 	provisioner := NewInstancePlugin(clientMock)
-	id, err := provisioner.Provision(json.RawMessage("{}"), tags, "", nil, nil)
+	id, err := provisioner.Provision(instance.Spec{Properties: json.RawMessage("{}"), Tags: tags})
 
 	require.Error(t, err)
 	require.Nil(t, id)

--- a/mock/ec2/mock_ec2iface.go
+++ b/mock/ec2/mock_ec2iface.go
@@ -1944,6 +1944,50 @@ func (_mr *_MockEC2APIRecorder) DescribeFlowLogsRequest(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeFlowLogsRequest", arg0)
 }
 
+func (_m *MockEC2API) DescribeHostReservationOfferings(_param0 *ec2.DescribeHostReservationOfferingsInput) (*ec2.DescribeHostReservationOfferingsOutput, error) {
+	ret := _m.ctrl.Call(_m, "DescribeHostReservationOfferings", _param0)
+	ret0, _ := ret[0].(*ec2.DescribeHostReservationOfferingsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeHostReservationOfferings(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeHostReservationOfferings", arg0)
+}
+
+func (_m *MockEC2API) DescribeHostReservationOfferingsRequest(_param0 *ec2.DescribeHostReservationOfferingsInput) (*request.Request, *ec2.DescribeHostReservationOfferingsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeHostReservationOfferingsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeHostReservationOfferingsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeHostReservationOfferingsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeHostReservationOfferingsRequest", arg0)
+}
+
+func (_m *MockEC2API) DescribeHostReservations(_param0 *ec2.DescribeHostReservationsInput) (*ec2.DescribeHostReservationsOutput, error) {
+	ret := _m.ctrl.Call(_m, "DescribeHostReservations", _param0)
+	ret0, _ := ret[0].(*ec2.DescribeHostReservationsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeHostReservations(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeHostReservations", arg0)
+}
+
+func (_m *MockEC2API) DescribeHostReservationsRequest(_param0 *ec2.DescribeHostReservationsInput) (*request.Request, *ec2.DescribeHostReservationsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeHostReservationsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeHostReservationsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeHostReservationsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeHostReservationsRequest", arg0)
+}
+
 func (_m *MockEC2API) DescribeHosts(_param0 *ec2.DescribeHostsInput) (*ec2.DescribeHostsOutput, error) {
 	ret := _m.ctrl.Call(_m, "DescribeHosts", _param0)
 	ret0, _ := ret[0].(*ec2.DescribeHostsOutput)
@@ -3540,6 +3584,28 @@ func (_mr *_MockEC2APIRecorder) GetConsoleScreenshotRequest(arg0 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetConsoleScreenshotRequest", arg0)
 }
 
+func (_m *MockEC2API) GetHostReservationPurchasePreview(_param0 *ec2.GetHostReservationPurchasePreviewInput) (*ec2.GetHostReservationPurchasePreviewOutput, error) {
+	ret := _m.ctrl.Call(_m, "GetHostReservationPurchasePreview", _param0)
+	ret0, _ := ret[0].(*ec2.GetHostReservationPurchasePreviewOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) GetHostReservationPurchasePreview(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetHostReservationPurchasePreview", arg0)
+}
+
+func (_m *MockEC2API) GetHostReservationPurchasePreviewRequest(_param0 *ec2.GetHostReservationPurchasePreviewInput) (*request.Request, *ec2.GetHostReservationPurchasePreviewOutput) {
+	ret := _m.ctrl.Call(_m, "GetHostReservationPurchasePreviewRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.GetHostReservationPurchasePreviewOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) GetHostReservationPurchasePreviewRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetHostReservationPurchasePreviewRequest", arg0)
+}
+
 func (_m *MockEC2API) GetPasswordData(_param0 *ec2.GetPasswordDataInput) (*ec2.GetPasswordDataOutput, error) {
 	ret := _m.ctrl.Call(_m, "GetPasswordData", _param0)
 	ret0, _ := ret[0].(*ec2.GetPasswordDataOutput)
@@ -4044,6 +4110,28 @@ func (_m *MockEC2API) MoveAddressToVpcRequest(_param0 *ec2.MoveAddressToVpcInput
 
 func (_mr *_MockEC2APIRecorder) MoveAddressToVpcRequest(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "MoveAddressToVpcRequest", arg0)
+}
+
+func (_m *MockEC2API) PurchaseHostReservation(_param0 *ec2.PurchaseHostReservationInput) (*ec2.PurchaseHostReservationOutput, error) {
+	ret := _m.ctrl.Call(_m, "PurchaseHostReservation", _param0)
+	ret0, _ := ret[0].(*ec2.PurchaseHostReservationOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) PurchaseHostReservation(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PurchaseHostReservation", arg0)
+}
+
+func (_m *MockEC2API) PurchaseHostReservationRequest(_param0 *ec2.PurchaseHostReservationInput) (*request.Request, *ec2.PurchaseHostReservationOutput) {
+	ret := _m.ctrl.Call(_m, "PurchaseHostReservationRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.PurchaseHostReservationOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) PurchaseHostReservationRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PurchaseHostReservationRequest", arg0)
 }
 
 func (_m *MockEC2API) PurchaseReservedInstancesOffering(_param0 *ec2.PurchaseReservedInstancesOfferingInput) (*ec2.PurchaseReservedInstancesOfferingOutput, error) {
@@ -4660,4 +4748,304 @@ func (_m *MockEC2API) UnmonitorInstancesRequest(_param0 *ec2.UnmonitorInstancesI
 
 func (_mr *_MockEC2APIRecorder) UnmonitorInstancesRequest(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UnmonitorInstancesRequest", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilBundleTaskComplete(_param0 *ec2.DescribeBundleTasksInput) error {
+	ret := _m.ctrl.Call(_m, "WaitUntilBundleTaskComplete", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilBundleTaskComplete(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilBundleTaskComplete", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilConversionTaskCancelled(_param0 *ec2.DescribeConversionTasksInput) error {
+	ret := _m.ctrl.Call(_m, "WaitUntilConversionTaskCancelled", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilConversionTaskCancelled(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilConversionTaskCancelled", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilConversionTaskCompleted(_param0 *ec2.DescribeConversionTasksInput) error {
+	ret := _m.ctrl.Call(_m, "WaitUntilConversionTaskCompleted", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilConversionTaskCompleted(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilConversionTaskCompleted", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilConversionTaskDeleted(_param0 *ec2.DescribeConversionTasksInput) error {
+	ret := _m.ctrl.Call(_m, "WaitUntilConversionTaskDeleted", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilConversionTaskDeleted(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilConversionTaskDeleted", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilCustomerGatewayAvailable(_param0 *ec2.DescribeCustomerGatewaysInput) error {
+	ret := _m.ctrl.Call(_m, "WaitUntilCustomerGatewayAvailable", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilCustomerGatewayAvailable(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilCustomerGatewayAvailable", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilExportTaskCancelled(_param0 *ec2.DescribeExportTasksInput) error {
+	ret := _m.ctrl.Call(_m, "WaitUntilExportTaskCancelled", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilExportTaskCancelled(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilExportTaskCancelled", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilExportTaskCompleted(_param0 *ec2.DescribeExportTasksInput) error {
+	ret := _m.ctrl.Call(_m, "WaitUntilExportTaskCompleted", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilExportTaskCompleted(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilExportTaskCompleted", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilImageAvailable(_param0 *ec2.DescribeImagesInput) error {
+	ret := _m.ctrl.Call(_m, "WaitUntilImageAvailable", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilImageAvailable(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilImageAvailable", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilImageExists(_param0 *ec2.DescribeImagesInput) error {
+	ret := _m.ctrl.Call(_m, "WaitUntilImageExists", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilImageExists(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilImageExists", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilInstanceExists(_param0 *ec2.DescribeInstancesInput) error {
+	ret := _m.ctrl.Call(_m, "WaitUntilInstanceExists", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilInstanceExists(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilInstanceExists", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilInstanceRunning(_param0 *ec2.DescribeInstancesInput) error {
+	ret := _m.ctrl.Call(_m, "WaitUntilInstanceRunning", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilInstanceRunning(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilInstanceRunning", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilInstanceStatusOk(_param0 *ec2.DescribeInstanceStatusInput) error {
+	ret := _m.ctrl.Call(_m, "WaitUntilInstanceStatusOk", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilInstanceStatusOk(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilInstanceStatusOk", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilInstanceStopped(_param0 *ec2.DescribeInstancesInput) error {
+	ret := _m.ctrl.Call(_m, "WaitUntilInstanceStopped", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilInstanceStopped(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilInstanceStopped", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilInstanceTerminated(_param0 *ec2.DescribeInstancesInput) error {
+	ret := _m.ctrl.Call(_m, "WaitUntilInstanceTerminated", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilInstanceTerminated(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilInstanceTerminated", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilKeyPairExists(_param0 *ec2.DescribeKeyPairsInput) error {
+	ret := _m.ctrl.Call(_m, "WaitUntilKeyPairExists", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilKeyPairExists(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilKeyPairExists", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilNatGatewayAvailable(_param0 *ec2.DescribeNatGatewaysInput) error {
+	ret := _m.ctrl.Call(_m, "WaitUntilNatGatewayAvailable", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilNatGatewayAvailable(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilNatGatewayAvailable", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilNetworkInterfaceAvailable(_param0 *ec2.DescribeNetworkInterfacesInput) error {
+	ret := _m.ctrl.Call(_m, "WaitUntilNetworkInterfaceAvailable", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilNetworkInterfaceAvailable(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilNetworkInterfaceAvailable", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilPasswordDataAvailable(_param0 *ec2.GetPasswordDataInput) error {
+	ret := _m.ctrl.Call(_m, "WaitUntilPasswordDataAvailable", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilPasswordDataAvailable(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilPasswordDataAvailable", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilSnapshotCompleted(_param0 *ec2.DescribeSnapshotsInput) error {
+	ret := _m.ctrl.Call(_m, "WaitUntilSnapshotCompleted", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilSnapshotCompleted(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilSnapshotCompleted", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilSpotInstanceRequestFulfilled(_param0 *ec2.DescribeSpotInstanceRequestsInput) error {
+	ret := _m.ctrl.Call(_m, "WaitUntilSpotInstanceRequestFulfilled", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilSpotInstanceRequestFulfilled(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilSpotInstanceRequestFulfilled", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilSubnetAvailable(_param0 *ec2.DescribeSubnetsInput) error {
+	ret := _m.ctrl.Call(_m, "WaitUntilSubnetAvailable", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilSubnetAvailable(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilSubnetAvailable", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilSystemStatusOk(_param0 *ec2.DescribeInstanceStatusInput) error {
+	ret := _m.ctrl.Call(_m, "WaitUntilSystemStatusOk", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilSystemStatusOk(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilSystemStatusOk", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilVolumeAvailable(_param0 *ec2.DescribeVolumesInput) error {
+	ret := _m.ctrl.Call(_m, "WaitUntilVolumeAvailable", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilVolumeAvailable(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilVolumeAvailable", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilVolumeDeleted(_param0 *ec2.DescribeVolumesInput) error {
+	ret := _m.ctrl.Call(_m, "WaitUntilVolumeDeleted", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilVolumeDeleted(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilVolumeDeleted", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilVolumeInUse(_param0 *ec2.DescribeVolumesInput) error {
+	ret := _m.ctrl.Call(_m, "WaitUntilVolumeInUse", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilVolumeInUse(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilVolumeInUse", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilVpcAvailable(_param0 *ec2.DescribeVpcsInput) error {
+	ret := _m.ctrl.Call(_m, "WaitUntilVpcAvailable", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilVpcAvailable(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilVpcAvailable", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilVpcExists(_param0 *ec2.DescribeVpcsInput) error {
+	ret := _m.ctrl.Call(_m, "WaitUntilVpcExists", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilVpcExists(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilVpcExists", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilVpcPeeringConnectionExists(_param0 *ec2.DescribeVpcPeeringConnectionsInput) error {
+	ret := _m.ctrl.Call(_m, "WaitUntilVpcPeeringConnectionExists", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilVpcPeeringConnectionExists(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilVpcPeeringConnectionExists", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilVpnConnectionAvailable(_param0 *ec2.DescribeVpnConnectionsInput) error {
+	ret := _m.ctrl.Call(_m, "WaitUntilVpnConnectionAvailable", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilVpnConnectionAvailable(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilVpnConnectionAvailable", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilVpnConnectionDeleted(_param0 *ec2.DescribeVpnConnectionsInput) error {
+	ret := _m.ctrl.Call(_m, "WaitUntilVpnConnectionDeleted", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilVpnConnectionDeleted(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilVpnConnectionDeleted", arg0)
 }

--- a/plugin/awsgroup/main.go
+++ b/plugin/awsgroup/main.go
@@ -1,0 +1,48 @@
+// This is a demo program for creating ana manading groups in AWS.  It will no longer be necessary once
+// plugin discovery is implemented.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	machete_aws "github.com/docker/libmachete.aws"
+	"github.com/docker/libmachete/plugin/group/groupserver"
+	"github.com/docker/libmachete/spi/instance"
+)
+
+func main() {
+	pluginLookup := func(key string) (instance.Plugin, error) {
+		switch key {
+		case "aws":
+			providers := []credentials.Provider{
+				&ec2rolecreds.EC2RoleProvider{Client: ec2metadata.New(session.New())},
+				&credentials.EnvProvider{},
+				&credentials.SharedCredentialsProvider{},
+			}
+
+			region, err := machete_aws.GetRegion()
+			if err != nil {
+				return nil, fmt.Errorf("Failed to determine local region: %s", err)
+			}
+
+			client := session.New(aws.NewConfig().
+				WithRegion(region).
+				WithCredentials(credentials.NewChainCredentials(providers)).
+				WithLogger(machete_aws.GetLogger()).
+				WithMaxRetries(3))
+
+			return machete_aws.NewInstancePlugin(ec2.New(client)), nil
+		default:
+			return nil, errors.New("Unknown instance plugin")
+		}
+	}
+
+	groupserver.Run(pluginLookup)
+}

--- a/plugin/instance/instance.go
+++ b/plugin/instance/instance.go
@@ -42,13 +42,13 @@ func (h *instanceHandler) provision(req *http.Request) (interface{}, error) {
 		return nil, spi.NewError(spi.ErrUnknown, fmt.Sprintf("Failed to unmarshal response: %s", err))
 	}
 
-	return h.provisioner.Provision(
-		*request.Request,
-		request.Tags,
-		request.BootScript,
-		request.PrivateIP,
-		request.Volume,
-	)
+	return h.provisioner.Provision(instance.Spec{
+		Properties:       *request.Request,
+		Tags:             request.Tags,
+		InitScript:       request.InitScript,
+		PrivateIPAddress: request.PrivateIP,
+		Volume:           request.Volume,
+	})
 }
 
 func (h *instanceHandler) destroy(req *http.Request) (interface{}, error) {

--- a/plugin/instance/types.go
+++ b/plugin/instance/types.go
@@ -11,7 +11,7 @@ import (
 type ProvisionRequest struct {
 	Request    *json.RawMessage
 	Tags       map[string]string
-	BootScript string
+	InitScript string
 	PrivateIP  *string
 	Volume     *instance.VolumeID
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,166 +3,191 @@
 	"ignore": "test",
 	"package": [
 		{
+			"checksumSHA1": "vzPNBiOJFecKT9FA6aAtmOjRlgs=",
+			"origin": "github.com/docker/libmachete/vendor/github.com/Microsoft/go-winio",
+			"path": "github.com/Microsoft/go-winio",
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
+		},
+		{
 			"checksumSHA1": "yXrS4e4yxaRBu/MX+39X3cS4kbg=",
 			"path": "github.com/Sirupsen/logrus",
 			"revision": "a283a10442df8dc09befd873fab202bf8a253d6a",
 			"revisionTime": "2016-07-16T02:56:31Z"
 		},
 		{
-			"checksumSHA1": "2wxpyfTXZB9X/L0m6c0oxTHsOxQ=",
+			"checksumSHA1": "Ex4zN+CcY/wtoDoK/penrVAxAok=",
 			"path": "github.com/aws/aws-sdk-go/aws",
-			"revision": "00e2bf9d1518c2b7d8a97eb05b5d2a9afd1dd34e",
-			"revisionTime": "2016-08-03T00:03:18Z"
+			"revision": "b2dc98bb584e48b0f5f39c93110633173c5da43c",
+			"revisionTime": "2016-09-16T20:28:04Z"
 		},
 		{
 			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
 			"path": "github.com/aws/aws-sdk-go/aws/awserr",
-			"revision": "00e2bf9d1518c2b7d8a97eb05b5d2a9afd1dd34e",
-			"revisionTime": "2016-08-03T00:03:18Z"
+			"revision": "b2dc98bb584e48b0f5f39c93110633173c5da43c",
+			"revisionTime": "2016-09-16T20:28:04Z"
 		},
 		{
-			"checksumSHA1": "dkfyy7aRNZ6BmUZ4ZdLIcMMXiPA=",
+			"checksumSHA1": "+q4vdl3l1Wom8K1wfIpJ4jlFsbY=",
 			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"revision": "00e2bf9d1518c2b7d8a97eb05b5d2a9afd1dd34e",
-			"revisionTime": "2016-08-03T00:03:18Z"
+			"revision": "b2dc98bb584e48b0f5f39c93110633173c5da43c",
+			"revisionTime": "2016-09-16T20:28:04Z"
 		},
 		{
-			"checksumSHA1": "RsYlRfQceaAgqjIrExwNsb/RBEM=",
+			"checksumSHA1": "H/tMKHZU+Qka6RtYiGB50s2uA0s=",
 			"path": "github.com/aws/aws-sdk-go/aws/client",
-			"revision": "00e2bf9d1518c2b7d8a97eb05b5d2a9afd1dd34e",
-			"revisionTime": "2016-08-03T00:03:18Z"
+			"revision": "b2dc98bb584e48b0f5f39c93110633173c5da43c",
+			"revisionTime": "2016-09-16T20:28:04Z"
 		},
 		{
 			"checksumSHA1": "ieAJ+Cvp/PKv1LpUEnUXpc3OI6E=",
 			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"revision": "00e2bf9d1518c2b7d8a97eb05b5d2a9afd1dd34e",
-			"revisionTime": "2016-08-03T00:03:18Z"
+			"revision": "b2dc98bb584e48b0f5f39c93110633173c5da43c",
+			"revisionTime": "2016-09-16T20:28:04Z"
 		},
 		{
 			"checksumSHA1": "gNWirlrTfSLbOe421hISBAhTqa4=",
 			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"revision": "00e2bf9d1518c2b7d8a97eb05b5d2a9afd1dd34e",
-			"revisionTime": "2016-08-03T00:03:18Z"
+			"revision": "b2dc98bb584e48b0f5f39c93110633173c5da43c",
+			"revisionTime": "2016-09-16T20:28:04Z"
 		},
 		{
 			"checksumSHA1": "dNZNaOPfBPnzE2CBnfhXXZ9g9jU=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials",
-			"revision": "00e2bf9d1518c2b7d8a97eb05b5d2a9afd1dd34e",
-			"revisionTime": "2016-08-03T00:03:18Z"
+			"revision": "b2dc98bb584e48b0f5f39c93110633173c5da43c",
+			"revisionTime": "2016-09-16T20:28:04Z"
 		},
 		{
 			"checksumSHA1": "KQiUK/zr3mqnAXD7x/X55/iNme0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"revision": "00e2bf9d1518c2b7d8a97eb05b5d2a9afd1dd34e",
-			"revisionTime": "2016-08-03T00:03:18Z"
+			"revision": "b2dc98bb584e48b0f5f39c93110633173c5da43c",
+			"revisionTime": "2016-09-16T20:28:04Z"
 		},
 		{
 			"checksumSHA1": "NUJUTWlc1sV8b7WjfiYc4JZbXl0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
-			"revision": "00e2bf9d1518c2b7d8a97eb05b5d2a9afd1dd34e",
-			"revisionTime": "2016-08-03T00:03:18Z"
+			"revision": "b2dc98bb584e48b0f5f39c93110633173c5da43c",
+			"revisionTime": "2016-09-16T20:28:04Z"
 		},
 		{
 			"checksumSHA1": "4Ipx+5xN0gso+cENC2MHMWmQlR4=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-			"revision": "00e2bf9d1518c2b7d8a97eb05b5d2a9afd1dd34e",
-			"revisionTime": "2016-08-03T00:03:18Z"
+			"revision": "b2dc98bb584e48b0f5f39c93110633173c5da43c",
+			"revisionTime": "2016-09-16T20:28:04Z"
 		},
 		{
-			"checksumSHA1": "dVqXFA18tta86y9KIfBqejJRI8Q=",
+			"checksumSHA1": "nCMd1XKjgV21bEl7J8VZFqTV8PE=",
 			"path": "github.com/aws/aws-sdk-go/aws/defaults",
-			"revision": "00e2bf9d1518c2b7d8a97eb05b5d2a9afd1dd34e",
-			"revisionTime": "2016-08-03T00:03:18Z"
+			"revision": "b2dc98bb584e48b0f5f39c93110633173c5da43c",
+			"revisionTime": "2016-09-16T20:28:04Z"
 		},
 		{
 			"checksumSHA1": "U0SthWum+t9ACanK7SDJOg3dO6M=",
 			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"revision": "00e2bf9d1518c2b7d8a97eb05b5d2a9afd1dd34e",
-			"revisionTime": "2016-08-03T00:03:18Z"
+			"revision": "b2dc98bb584e48b0f5f39c93110633173c5da43c",
+			"revisionTime": "2016-09-16T20:28:04Z"
 		},
 		{
-			"checksumSHA1": "NyUg1P8ZS/LHAAQAk/4C5O4X3og=",
+			"checksumSHA1": "UeUNU97No2/+pICBYrFevJAaShs=",
 			"path": "github.com/aws/aws-sdk-go/aws/request",
-			"revision": "00e2bf9d1518c2b7d8a97eb05b5d2a9afd1dd34e",
-			"revisionTime": "2016-08-03T00:03:18Z"
+			"revision": "b2dc98bb584e48b0f5f39c93110633173c5da43c",
+			"revisionTime": "2016-09-16T20:28:04Z"
 		},
 		{
-			"checksumSHA1": "WGJSBor5XUHGttPG7kTbW/g27kQ=",
+			"checksumSHA1": "44uohX3kLsfZHHOqunr+qJnSCdw=",
 			"path": "github.com/aws/aws-sdk-go/aws/session",
-			"revision": "00e2bf9d1518c2b7d8a97eb05b5d2a9afd1dd34e",
-			"revisionTime": "2016-08-03T00:03:18Z"
+			"revision": "b2dc98bb584e48b0f5f39c93110633173c5da43c",
+			"revisionTime": "2016-09-16T20:28:04Z"
 		},
 		{
 			"checksumSHA1": "7lla+sckQeF18wORAGuU2fFMlp4=",
 			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
-			"revision": "00e2bf9d1518c2b7d8a97eb05b5d2a9afd1dd34e",
-			"revisionTime": "2016-08-03T00:03:18Z"
+			"revision": "b2dc98bb584e48b0f5f39c93110633173c5da43c",
+			"revisionTime": "2016-09-16T20:28:04Z"
 		},
 		{
-			"checksumSHA1": "sgft7A0lRCVD7QBogydg46lr3NM=",
+			"checksumSHA1": "Bm6UrYb2QCzpYseLwwgw6aetgRc=",
 			"path": "github.com/aws/aws-sdk-go/private/endpoints",
-			"revision": "00e2bf9d1518c2b7d8a97eb05b5d2a9afd1dd34e",
-			"revisionTime": "2016-08-03T00:03:18Z"
+			"revision": "b2dc98bb584e48b0f5f39c93110633173c5da43c",
+			"revisionTime": "2016-09-16T20:28:04Z"
 		},
 		{
 			"checksumSHA1": "wk7EyvDaHwb5qqoOP/4d3cV0708=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol",
-			"revision": "00e2bf9d1518c2b7d8a97eb05b5d2a9afd1dd34e",
-			"revisionTime": "2016-08-03T00:03:18Z"
+			"revision": "b2dc98bb584e48b0f5f39c93110633173c5da43c",
+			"revisionTime": "2016-09-16T20:28:04Z"
 		},
 		{
 			"checksumSHA1": "uNmSKXAF8B9HWEciW+iyUwZ99qQ=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/ec2query",
-			"revision": "00e2bf9d1518c2b7d8a97eb05b5d2a9afd1dd34e",
-			"revisionTime": "2016-08-03T00:03:18Z"
+			"revision": "b2dc98bb584e48b0f5f39c93110633173c5da43c",
+			"revisionTime": "2016-09-16T20:28:04Z"
 		},
 		{
 			"checksumSHA1": "isoix7lTx4qIq2zI2xFADtti5SI=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"revision": "00e2bf9d1518c2b7d8a97eb05b5d2a9afd1dd34e",
-			"revisionTime": "2016-08-03T00:03:18Z"
+			"revision": "b2dc98bb584e48b0f5f39c93110633173c5da43c",
+			"revisionTime": "2016-09-16T20:28:04Z"
 		},
 		{
 			"checksumSHA1": "5xzix1R8prUyWxgLnzUQoxTsfik=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"revision": "00e2bf9d1518c2b7d8a97eb05b5d2a9afd1dd34e",
-			"revisionTime": "2016-08-03T00:03:18Z"
+			"revision": "b2dc98bb584e48b0f5f39c93110633173c5da43c",
+			"revisionTime": "2016-09-16T20:28:04Z"
 		},
 		{
 			"checksumSHA1": "TW/7U+/8ormL7acf6z2rv2hDD+s=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"revision": "00e2bf9d1518c2b7d8a97eb05b5d2a9afd1dd34e",
-			"revisionTime": "2016-08-03T00:03:18Z"
+			"revision": "b2dc98bb584e48b0f5f39c93110633173c5da43c",
+			"revisionTime": "2016-09-16T20:28:04Z"
+		},
+		{
+			"checksumSHA1": "Y6Db2GGfGD9LPpcJIPj8vXE8BbQ=",
+			"path": "github.com/aws/aws-sdk-go/private/protocol/restxml",
+			"revision": "b2dc98bb584e48b0f5f39c93110633173c5da43c",
+			"revisionTime": "2016-09-16T20:28:04Z"
 		},
 		{
 			"checksumSHA1": "eUEkjyMPAuekKBE4ou+nM9tXEas=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"revision": "00e2bf9d1518c2b7d8a97eb05b5d2a9afd1dd34e",
-			"revisionTime": "2016-08-03T00:03:18Z"
+			"revision": "b2dc98bb584e48b0f5f39c93110633173c5da43c",
+			"revisionTime": "2016-09-16T20:28:04Z"
 		},
 		{
 			"checksumSHA1": "Eo9yODN5U99BK0pMzoqnBm7PCrY=",
 			"path": "github.com/aws/aws-sdk-go/private/waiter",
-			"revision": "00e2bf9d1518c2b7d8a97eb05b5d2a9afd1dd34e",
-			"revisionTime": "2016-08-03T00:03:18Z"
+			"revision": "b2dc98bb584e48b0f5f39c93110633173c5da43c",
+			"revisionTime": "2016-09-16T20:28:04Z"
 		},
 		{
-			"checksumSHA1": "Ao/Vq8RYiaW63HasBBPkNg/i7CM=",
+			"checksumSHA1": "FiQmUvjtJfroyEr3dFUSChrpq08=",
 			"path": "github.com/aws/aws-sdk-go/service/ec2",
-			"revision": "00e2bf9d1518c2b7d8a97eb05b5d2a9afd1dd34e",
-			"revisionTime": "2016-08-03T00:03:18Z"
+			"revision": "b2dc98bb584e48b0f5f39c93110633173c5da43c",
+			"revisionTime": "2016-09-16T20:28:04Z"
 		},
 		{
-			"checksumSHA1": "Xv+Vd1Cfd2iXdGUOUhZ6GgDmR90=",
+			"checksumSHA1": "gFA1+XsEzc7h587TliZaPDrbElU=",
 			"path": "github.com/aws/aws-sdk-go/service/ec2/ec2iface",
-			"revision": "00e2bf9d1518c2b7d8a97eb05b5d2a9afd1dd34e",
-			"revisionTime": "2016-08-03T00:03:18Z"
+			"revision": "b2dc98bb584e48b0f5f39c93110633173c5da43c",
+			"revisionTime": "2016-09-16T20:28:04Z"
+		},
+		{
+			"checksumSHA1": "dH2W7lR17dgn4a4OYiEzjpQH8hI=",
+			"path": "github.com/aws/aws-sdk-go/service/iam",
+			"revision": "b2dc98bb584e48b0f5f39c93110633173c5da43c",
+			"revisionTime": "2016-09-16T20:28:04Z"
+		},
+		{
+			"checksumSHA1": "imxJucuPrgaPRMPtAgsu+Y7soB4=",
+			"path": "github.com/aws/aws-sdk-go/service/s3",
+			"revision": "b2dc98bb584e48b0f5f39c93110633173c5da43c",
+			"revisionTime": "2016-09-16T20:28:04Z"
 		},
 		{
 			"checksumSHA1": "nH/itbdeFHpl4ysegdtgww9bFSA=",
 			"path": "github.com/aws/aws-sdk-go/service/sts",
-			"revision": "00e2bf9d1518c2b7d8a97eb05b5d2a9afd1dd34e",
-			"revisionTime": "2016-08-03T00:03:18Z"
+			"revision": "b2dc98bb584e48b0f5f39c93110633173c5da43c",
+			"revisionTime": "2016-09-16T20:28:04Z"
 		},
 		{
 			"checksumSHA1": "5rPfda8jFccr3A6heL+JAmi9K9g=",
@@ -172,29 +197,211 @@
 			"revisionTime": "2016-06-15T09:26:46Z"
 		},
 		{
-			"checksumSHA1": "hbcE4kI89SE5cX6dA7iWl/acpjU=",
+			"checksumSHA1": "f1wARLDzsF/JoyN01yoxXEwFIp8=",
+			"origin": "github.com/docker/libmachete/vendor/github.com/docker/distribution/digest",
+			"path": "github.com/docker/distribution/digest",
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
+		},
+		{
+			"checksumSHA1": "PzXRTLmmqWXxmDqdIXLcRYBma18=",
+			"origin": "github.com/docker/libmachete/vendor/github.com/docker/distribution/reference",
+			"path": "github.com/docker/distribution/reference",
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
+		},
+		{
+			"checksumSHA1": "eTDiSq90I43NEMwYVrlgBVs/1tk=",
+			"origin": "github.com/docker/libmachete/vendor/github.com/docker/engine-api/client",
+			"path": "github.com/docker/engine-api/client",
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
+		},
+		{
+			"checksumSHA1": "RcYDLK+XW1lSLDMSsLVQwepjV3Y=",
+			"origin": "github.com/docker/libmachete/vendor/github.com/docker/engine-api/client/transport",
+			"path": "github.com/docker/engine-api/client/transport",
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
+		},
+		{
+			"checksumSHA1": "dxUuki/mVVBKqsZ1n3RkBt+/cQM=",
+			"origin": "github.com/docker/libmachete/vendor/github.com/docker/engine-api/client/transport/cancellable",
+			"path": "github.com/docker/engine-api/client/transport/cancellable",
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
+		},
+		{
+			"checksumSHA1": "i7+jf4KGYi44xEzagx69j82galk=",
+			"origin": "github.com/docker/libmachete/vendor/github.com/docker/engine-api/types",
+			"path": "github.com/docker/engine-api/types",
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
+		},
+		{
+			"checksumSHA1": "ry5lgawDzJEEFNOgiLkAj7yJH6E=",
+			"origin": "github.com/docker/libmachete/vendor/github.com/docker/engine-api/types/blkiodev",
+			"path": "github.com/docker/engine-api/types/blkiodev",
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
+		},
+		{
+			"checksumSHA1": "tfdtNIft76G0i5gU/3LHtpHLIxQ=",
+			"origin": "github.com/docker/libmachete/vendor/github.com/docker/engine-api/types/container",
+			"path": "github.com/docker/engine-api/types/container",
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
+		},
+		{
+			"checksumSHA1": "hZV62Xzt/i0e/WBKWww3rpkRAR4=",
+			"origin": "github.com/docker/libmachete/vendor/github.com/docker/engine-api/types/filters",
+			"path": "github.com/docker/engine-api/types/filters",
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
+		},
+		{
+			"checksumSHA1": "Khzf7tXOZxxJy/5BCHD3aINtyU8=",
+			"origin": "github.com/docker/libmachete/vendor/github.com/docker/engine-api/types/network",
+			"path": "github.com/docker/engine-api/types/network",
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
+		},
+		{
+			"checksumSHA1": "DrGaE4uA19LswH15o/LVYxs7TgE=",
+			"origin": "github.com/docker/libmachete/vendor/github.com/docker/engine-api/types/reference",
+			"path": "github.com/docker/engine-api/types/reference",
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
+		},
+		{
+			"checksumSHA1": "Yto1DJP+S7aiRrNiEqDDqxe+mSo=",
+			"origin": "github.com/docker/libmachete/vendor/github.com/docker/engine-api/types/registry",
+			"path": "github.com/docker/engine-api/types/registry",
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
+		},
+		{
+			"checksumSHA1": "Mgvb6aJiQKpzcOQy5LpfpWrM5L0=",
+			"origin": "github.com/docker/libmachete/vendor/github.com/docker/engine-api/types/strslice",
+			"path": "github.com/docker/engine-api/types/strslice",
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
+		},
+		{
+			"checksumSHA1": "L1FtVN7cfHzjcSSkW/EkwQEVDuM=",
+			"origin": "github.com/docker/libmachete/vendor/github.com/docker/engine-api/types/swarm",
+			"path": "github.com/docker/engine-api/types/swarm",
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
+		},
+		{
+			"checksumSHA1": "NXxuzwsg/CA+CM56b+ViwOdO9T0=",
+			"origin": "github.com/docker/libmachete/vendor/github.com/docker/engine-api/types/time",
+			"path": "github.com/docker/engine-api/types/time",
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
+		},
+		{
+			"checksumSHA1": "AE3TTpPWvv9ic71FiF0HnRr46mE=",
+			"origin": "github.com/docker/libmachete/vendor/github.com/docker/engine-api/types/versions",
+			"path": "github.com/docker/engine-api/types/versions",
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
+		},
+		{
+			"checksumSHA1": "lEqVJt7+iIa0nMKYWIUoQhh9VTM=",
+			"origin": "github.com/docker/libmachete/vendor/github.com/docker/go-connections/nat",
+			"path": "github.com/docker/go-connections/nat",
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
+		},
+		{
+			"checksumSHA1": "3sQ35fcqLJRnyTqaZn8Zb9l97uk=",
+			"origin": "github.com/docker/libmachete/vendor/github.com/docker/go-connections/sockets",
+			"path": "github.com/docker/go-connections/sockets",
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
+		},
+		{
+			"checksumSHA1": "xGJFkVcAiqRU53KFeF9tJuHUiJY=",
+			"origin": "github.com/docker/libmachete/vendor/github.com/docker/go-connections/tlsconfig",
+			"path": "github.com/docker/go-connections/tlsconfig",
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
+		},
+		{
+			"checksumSHA1": "KbWP8VsU9gVoZm9pCqe79AkfDmk=",
+			"origin": "github.com/docker/libmachete/vendor/github.com/docker/go-units",
+			"path": "github.com/docker/go-units",
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
+		},
+		{
+			"checksumSHA1": "9CFe0GCuph6UB+blD/4Z4fwURlM=",
 			"path": "github.com/docker/libmachete/controller/util",
-			"revision": "b4f8a7a177772526e61b9fe5b82a28cbc4090e1e",
-			"revisionTime": "2016-09-16T02:51:55Z"
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
+		},
+		{
+			"checksumSHA1": "C4JomKmkdUxzYtaObAQjzIGr4U0=",
+			"path": "github.com/docker/libmachete/controller/watcher",
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
+		},
+		{
+			"checksumSHA1": "CMiZYux9SxTDmI1tirzyMZolJhE=",
+			"path": "github.com/docker/libmachete/plugin/group",
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
+		},
+		{
+			"checksumSHA1": "tmBv3JGwYGm+A2Qh4gXV5TELGfQ=",
+			"path": "github.com/docker/libmachete/plugin/group/groupserver",
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
+		},
+		{
+			"checksumSHA1": "aLg0ONv8LzLxfrOvZvSuR0HFJFw=",
+			"path": "github.com/docker/libmachete/plugin/group/swarm",
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
+		},
+		{
+			"checksumSHA1": "tutCAqeV+vlPp/CExesBc39C66Y=",
+			"path": "github.com/docker/libmachete/plugin/group/types",
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
+		},
+		{
+			"checksumSHA1": "rPmvlaQGSEEjaWMeK+oNbipO1Dg=",
+			"path": "github.com/docker/libmachete/plugin/group/util",
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
 		},
 		{
 			"checksumSHA1": "yXXIyc9tG6BaOCvX2PBSQAkUYjA=",
 			"path": "github.com/docker/libmachete/spi",
-			"revision": "b4f8a7a177772526e61b9fe5b82a28cbc4090e1e",
-			"revisionTime": "2016-09-16T02:51:55Z"
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
 		},
 		{
-			"checksumSHA1": "gyz5mwvb6map2UJ6tkEeMOS3OC4=",
+			"checksumSHA1": "0nDC7GE9rXxd+dDF+QAzsbc1u3Y=",
+			"path": "github.com/docker/libmachete/spi/group",
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
+		},
+		{
+			"checksumSHA1": "0Q9RA635PdTTF5dScDAPutEKk7c=",
 			"path": "github.com/docker/libmachete/spi/instance",
-			"revision": "b4f8a7a177772526e61b9fe5b82a28cbc4090e1e",
-			"revisionTime": "2016-09-16T02:51:55Z"
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
 		},
 		{
 			"checksumSHA1": "FCeEm2BWZV/n4oTy+SGd/k0Ab5c=",
 			"origin": "github.com/aws/aws-sdk-go/vendor/github.com/go-ini/ini",
 			"path": "github.com/go-ini/ini",
-			"revision": "00e2bf9d1518c2b7d8a97eb05b5d2a9afd1dd34e",
-			"revisionTime": "2016-08-03T00:03:18Z"
+			"revision": "b2dc98bb584e48b0f5f39c93110633173c5da43c",
+			"revisionTime": "2016-09-16T20:28:04Z"
 		},
 		{
 			"checksumSHA1": "JSHl8b3nI8EWvzm+uyrIqj2Hiu4=",
@@ -224,8 +431,15 @@
 			"checksumSHA1": "0ZrwvB6KoGPj2PoDNSEJwxQ6Mog=",
 			"origin": "github.com/aws/aws-sdk-go/vendor/github.com/jmespath/go-jmespath",
 			"path": "github.com/jmespath/go-jmespath",
-			"revision": "00e2bf9d1518c2b7d8a97eb05b5d2a9afd1dd34e",
-			"revisionTime": "2016-08-03T00:03:18Z"
+			"revision": "b2dc98bb584e48b0f5f39c93110633173c5da43c",
+			"revisionTime": "2016-09-16T20:28:04Z"
+		},
+		{
+			"checksumSHA1": "3AoPMXlmVq2+iWMpsdJZkcUKHB8=",
+			"origin": "github.com/docker/libmachete/vendor/github.com/opencontainers/runc/libcontainer/user",
+			"path": "github.com/opencontainers/runc/libcontainer/user",
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
 		},
 		{
 			"checksumSHA1": "zKKp5SZ3d3ycKe4EKMNT0BqAWBw=",
@@ -259,10 +473,31 @@
 			"revisionTime": "2016-06-15T09:26:46Z"
 		},
 		{
+			"checksumSHA1": "9jjO5GjLa0XF/nfWihF02RoH4qc=",
+			"origin": "github.com/docker/libmachete/vendor/golang.org/x/net/context",
+			"path": "golang.org/x/net/context",
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
+		},
+		{
+			"checksumSHA1": "LvdVRE0FqdR68SvVpRkHs1rxhcA=",
+			"origin": "github.com/docker/libmachete/vendor/golang.org/x/net/proxy",
+			"path": "golang.org/x/net/proxy",
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
+		},
+		{
 			"checksumSHA1": "8fD/im5Kwvy3JgmxulDTambmE8w=",
 			"path": "golang.org/x/sys/unix",
 			"revision": "a646d33e2ee3172a661fc09bca23bb4889a41bc8",
 			"revisionTime": "2016-07-15T05:43:45Z"
+		},
+		{
+			"checksumSHA1": "fpW2dhGFC6SrVzipJx7fjg2DIH8=",
+			"origin": "github.com/docker/libmachete/vendor/golang.org/x/sys/windows",
+			"path": "golang.org/x/sys/windows",
+			"revision": "8b1938a16488378d60bef7afb940062606c4b6b4",
+			"revisionTime": "2016-09-20T23:46:31Z"
 		}
 	],
 	"rootPath": "github.com/docker/libmachete.aws"


### PR DESCRIPTION
Nearly all of the bootstrapping code has been lifted from the libmachete
repo, and has little to no changes.  There is a newly-introduced CLI tool
to build the default libmachete Group plugin with the AWS instance plugin.
