### PR TITLE
Include a resource namespace for instances

### DIFF
--- a/experimental/bootstrap/create.go
+++ b/experimental/bootstrap/create.go
@@ -480,7 +480,7 @@ docker run --rm $discovery -v $configs:$configs $image infrakit group watch $con
 func startInitialManager(config client.ConfigProvider, spec clusterSpec) error {
 	log.Info("Starting cluster boot leader instance")
 	builder := infrakit_instance.Builder{Config: config}
-	provisioner, err := builder.BuildInstancePlugin()
+	provisioner, err := builder.BuildInstancePlugin(spec.cluster().clusterTagMap())
 	if err != nil {
 		return err
 	}

--- a/experimental/bootstrap/schema.go
+++ b/experimental/bootstrap/schema.go
@@ -18,6 +18,7 @@ import (
 const (
 	workerType  = "worker"
 	managerType = "manager"
+	clusterTag  = "infrakit.cluster"
 )
 
 type clusterID struct {
@@ -51,7 +52,7 @@ func (c clusterID) resourceFilter(vpcID string) []*ec2.Filter {
 
 func (c clusterID) clusterFilter() *ec2.Filter {
 	return &ec2.Filter{
-		Name:   aws.String("tag:infrakit.cluster"),
+		Name:   aws.String("tag:" + clusterTag),
 		Values: []*string{aws.String(c.name)},
 	}
 }
@@ -68,9 +69,13 @@ func (c clusterID) instanceProfileName() string {
 	return fmt.Sprintf("%s-ManagerProfile", c.name)
 }
 
+func (c clusterID) clusterTagMap() map[string]string {
+	return map[string]string{clusterTag: c.name}
+}
+
 func (c clusterID) resourceTag() *ec2.Tag {
 	return &ec2.Tag{
-		Key:   aws.String("infrakit.cluster"),
+		Key:   aws.String(clusterTag),
 		Value: aws.String(c.name),
 	}
 }

--- a/plugin/instance/builder.go
+++ b/plugin/instance/builder.go
@@ -41,7 +41,7 @@ func (b *Builder) Flags() *pflag.FlagSet {
 }
 
 // BuildInstancePlugin creates an instance Provisioner configured with the Flags.
-func (b *Builder) BuildInstancePlugin() (instance.Plugin, error) {
+func (b *Builder) BuildInstancePlugin(namespaceTags map[string]string) (instance.Plugin, error) {
 	if b.Config == nil {
 		providers := []credentials.Provider{
 			&ec2rolecreds.EC2RoleProvider{Client: ec2metadata.New(session.New())},
@@ -79,7 +79,7 @@ func (b *Builder) BuildInstancePlugin() (instance.Plugin, error) {
 			WithMaxRetries(b.options.retries))
 	}
 
-	return NewInstancePlugin(ec2.New(b.Config)), nil
+	return NewInstancePlugin(ec2.New(b.Config), namespaceTags), nil
 }
 
 type logger struct {

--- a/plugin/instance/cmd/main.go
+++ b/plugin/instance/cmd/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/infrakit/cli"
 	instance_plugin "github.com/docker/infrakit/rpc/instance"
 	"github.com/spf13/cobra"
+	"strings"
 )
 
 func main() {
@@ -16,12 +17,24 @@ func main() {
 
 	var logLevel int
 	var name string
+	var namespaceTags []string
 	cmd := &cobra.Command{
 		Use:   os.Args[0],
 		Short: "AWS instance plugin",
 		Run: func(c *cobra.Command, args []string) {
 
-			instancePlugin, err := builder.BuildInstancePlugin()
+			namespace := map[string]string{}
+			for _, tagKV := range namespaceTags {
+				keyAndValue := strings.Split(tagKV, "=")
+				if len(keyAndValue) != 2 {
+					log.Error("Namespace tags must be formatted as key=value")
+					os.Exit(1)
+				}
+
+				namespace[keyAndValue[0]] = keyAndValue[1]
+			}
+
+			instancePlugin, err := builder.BuildInstancePlugin(namespace)
 			if err != nil {
 				log.Error(err)
 				os.Exit(1)
@@ -34,6 +47,11 @@ func main() {
 
 	cmd.Flags().IntVar(&logLevel, "log", cli.DefaultLogLevel, "Logging level. 0 is least verbose. Max is 5")
 	cmd.Flags().StringVar(&name, "name", "instance-aws", "Plugin name to advertise for discovery")
+	cmd.Flags().StringSliceVar(
+		&namespaceTags,
+		"namespace-tags",
+		[]string{},
+		"A list of key=value resource tags to namespace all resources created")
 
 	// TODO(chungers) - the exposed flags here won't be set in plugins, because plugin install doesn't allow
 	// user to pass in command line args like containers with entrypoint.


### PR DESCRIPTION
This makes it easier to run the AWS instance plugin multiple times
simultaneously without interference

Signed-off-by: Bill Farner <bill@docker.com>