### PR TITLE
version strings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ clean:
 
 define build_binary
 	go build -o build/$(1) \
-		-ldflags "-X github.com/docker/infrakit/pkg/cli.Version=$(VERSION) -X github.com/docker/infrakit/pkg/cli.Revision=$(REVISION)" $(2)
+		-ldflags "-X github.com/docker/infrakit.aws/plugin.Version=$(VERSION) -X github.com/docker/infrakit.aws/plugin.Revision=$(REVISION)" $(2)
 endef
 binaries: clean build-binaries
 build-binaries:

--- a/plugin/instance/cmd/main.go
+++ b/plugin/instance/cmd/main.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/docker/infrakit.aws/plugin"
 	"github.com/docker/infrakit.aws/plugin/instance"
 	"github.com/docker/infrakit/pkg/cli"
 	instance_plugin "github.com/docker/infrakit/pkg/rpc/instance"
@@ -57,7 +58,7 @@ func main() {
 	// user to pass in command line args like containers with entrypoint.
 	cmd.Flags().AddFlagSet(builder.Flags())
 
-	cmd.AddCommand(cli.VersionCommand())
+	cmd.AddCommand(plugin.VersionCommand())
 
 	err := cmd.Execute()
 	if err != nil {

--- a/plugin/version.go
+++ b/plugin/version.go
@@ -1,0 +1,27 @@
+package plugin
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	// Version is the build release identifier.
+	Version = "Unspecified"
+
+	// Revision is the build source control revision.
+	Revision = "Unspecified"
+)
+
+// VersionCommand creates a cobra Command that prints build version information.
+func VersionCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "print build version information",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("Version: %s\n", Version)
+			fmt.Printf("Revision: %s\n", Revision)
+		},
+	}
+}


### PR DESCRIPTION
Fixes a problem where the version and revision strings don't show up.  Also fixes the LDFLAGS so that the correct git version / revisions are bound to package's exported variables.

Signed-off-by: David Chung <david.chung@docker.com>