### PR TITLE
Label instances without special 'aws:' prefix

### DIFF
--- a/dockerfiles/Dockerfile.bundle
+++ b/dockerfiles/Dockerfile.bundle
@@ -1,14 +1,17 @@
-FROM alpine:3.4
+FROM alpine:3.5
 
-# InfraKit.aws bundle: for AWS instance drivers
-# OSS - Use at your own risk - see project LICENSE for details
-
-MAINTAINER David Chung <david.chung@docker.com>
-
-RUN apk add --update ca-certificates && rm -Rf /tmp/* /var/lib/cache/apk/*
-RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
+RUN apk add --update ca-certificates
 
 RUN mkdir -p /infrakit/plugins /infrakit/configs /infrakit/logs
+
 VOLUME /infrakit
 
+ENV INFRAKIT_HOME /infrakit
+ENV INFRAKIT_PLUGINS_DIR /infrakit/plugins
+
 ADD build/* /usr/local/bin/
+
+# Make symbolic links to make standardized bin names.
+# This makes for shorter names when containers are already scoped by the platform (eg. infrakit/aws)
+RUN ln -s /usr/local/bin/infrakit-instance-aws /usr/bin/instance
+RUN ln -s /usr/local/bin/infrakit-metadata-aws /usr/bin/metadata

--- a/plugin/instance/instance.go
+++ b/plugin/instance/instance.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -134,7 +135,10 @@ func (p awsInstancePlugin) Label(id instance.ID, labels map[string]string) error
 	tags := []*ec2.Tag{}
 	for _, k := range keys {
 		key := k
-		tags = append(tags, &ec2.Tag{Key: aws.String(key), Value: aws.String(merged[key])})
+		// filter out the special aws: key because it's reserved so leave them alone
+		if strings.Index(key, "aws:") == -1 {
+			tags = append(tags, &ec2.Tag{Key: aws.String(key), Value: aws.String(merged[key])})
+		}
 	}
 
 	_, err = p.client.CreateTags(&ec2.CreateTagsInput{Resources: []*string{aws.String(string(id))}, Tags: tags})

--- a/vendor.conf
+++ b/vendor.conf
@@ -6,7 +6,7 @@ github.com/aokoli/goutils		1.0.0
 github.com/Sirupsen/logrus		v0.10.0-38-g3ec0642
 github.com/aws/aws-sdk-go		v1.4.20
 github.com/davecgh/go-spew		v1.0.0-3-g6d21280
-github.com/docker/infrakit		v0.4.0
+github.com/docker/infrakit		v0.4.1
 github.com/go-ini/ini			v1.21.1
 github.com/golang/mock			bd3c8e8
 github.com/gorilla/rpc			22c016f

--- a/vendor/github.com/docker/infrakit/pkg/plugin/metadata/reflect.go
+++ b/vendor/github.com/docker/infrakit/pkg/plugin/metadata/reflect.go
@@ -42,29 +42,27 @@ func List(path []string, object interface{}) []string {
 	if v == nil {
 		return list
 	}
-	if any, is := v.(*types.Any); is {
-		temp := map[string]interface{}{}
-		if err := any.Decode(&temp); err == nil {
-			if len(temp) > 0 {
-				return List([]string{"."}, temp)
-			}
-			return []string{}
-		}
-		return []string{}
-	}
 
 	val := reflect.Indirect(reflect.ValueOf(v))
+	if any, is := v.(*types.Any); is {
+		var temp interface{}
+		if err := any.Decode(&temp); err == nil {
+			val = reflect.ValueOf(temp)
+		}
+	}
+
 	switch val.Kind() {
 	case reflect.Slice:
 		// this is a slice, so return the name as '[%d]'
 		for i := 0; i < val.Len(); i++ {
-			list = append(list, fmt.Sprintf("[%d]", i)) //val.Index(i).String())
+			list = append(list, fmt.Sprintf("[%d]", i))
 		}
 
 	case reflect.Map:
 		for _, k := range val.MapKeys() {
 			list = append(list, k.String())
 		}
+
 	case reflect.Struct:
 		vt := val.Type()
 		for i := 0; i < vt.NumField(); i++ {
@@ -120,6 +118,14 @@ func put(p []string, value interface{}, store map[string]interface{}) bool {
 func get(path []string, object interface{}) interface{} {
 	if len(path) == 0 {
 		return object
+	}
+
+	if any, is := object.(*types.Any); is {
+		var temp interface{}
+		if err := any.Decode(&temp); err == nil {
+			return get(path, temp)
+		}
+		return nil
 	}
 
 	key := path[0]

--- a/vendor/github.com/docker/infrakit/pkg/template/template.go
+++ b/vendor/github.com/docker/infrakit/pkg/template/template.go
@@ -180,6 +180,10 @@ func (t *Template) forkFrom(parent *Template) (dotCopy interface{}, err error) {
 	for k, v := range parent.funcs {
 		t.AddFunc(k, v)
 	}
+	// inherit other functions
+	for _, ff := range parent.functions {
+		t.functions = append(t.functions, ff)
+	}
 	if parent.context != nil {
 		return DeepCopyObject(parent.context)
 	}


### PR DESCRIPTION
AWS EC2 api complains when labeling an instance with `aws:` prefix.  This PR filters out those labels when calling the AWS api.

Signed-off-by: David Chung <david.chung@docker.com>